### PR TITLE
Api/change query terms

### DIFF
--- a/genomics_data_index/api/query/SamplesQuery.py
+++ b/genomics_data_index/api/query/SamplesQuery.py
@@ -27,7 +27,8 @@ class SamplesQuery(abc.ABC):
 
     @abc.abstractmethod
     def join(self, data_frame: pd.DataFrame, sample_ids_column: str = None,
-             sample_names_column: str = None) -> SamplesQuery:
+             sample_names_column: str = None, default_isa_kind: str = 'names',
+             default_isa_column: str = None) -> SamplesQuery:
         """
         Joins the passed dataframe onto the current query using the passed column name in the dataframe.
         The column can either contain sample IDs (in sample_ids_column) or sample names (sample_names_column).
@@ -36,6 +37,11 @@ class SamplesQuery(abc.ABC):
         :param sample_ids_column: The column name in the data frame containing internal sample IDs used for joining.
         :param sample_names_column: The column name in the data frame containing sample names to join on.
                                     Internally these will be mapped to Sample IDs.
+        :param default_isa_kind: The default 'kind' parameter to isa(data, kind=kind, ...) queries. This is used
+                                 to simplify queries after joining with a dataframe in cases where you want
+                                 isa() to select by a particular column in the dataframe.
+        :param default_isa_column: If default_isa_kind is set to 'dataframe' sets the default column to use for
+                                   isa() queries.
         :return: A SamplesQuery representing the query joined with the data frame.
         """
         pass

--- a/genomics_data_index/api/query/SamplesQuery.py
+++ b/genomics_data_index/api/query/SamplesQuery.py
@@ -85,7 +85,7 @@ class SamplesQuery(abc.ABC):
     #     return self.isin(sample_names=sample_names, kind='distance')
 
     @abc.abstractmethod
-    def isin(self, sample_names: Union[str, List[str]], kind: str = 'distance', **kwargs) -> SamplesQuery:
+    def isin(self, data: Union[str, List[str]], kind: str = 'names', **kwargs) -> SamplesQuery:
         pass
 
     @abc.abstractmethod

--- a/genomics_data_index/api/query/SamplesQuery.py
+++ b/genomics_data_index/api/query/SamplesQuery.py
@@ -70,7 +70,7 @@ class SamplesQuery(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def has(self, property: Union[QueryFeature, str, pd.Series], kind=None) -> SamplesQuery:
+    def hasa(self, property: Union[QueryFeature, str, pd.Series], kind=None) -> SamplesQuery:
         pass
 
     @abc.abstractmethod

--- a/genomics_data_index/api/query/SamplesQuery.py
+++ b/genomics_data_index/api/query/SamplesQuery.py
@@ -73,16 +73,19 @@ class SamplesQuery(abc.ABC):
     def hasa(self, property: Union[QueryFeature, str, pd.Series], kind=None) -> SamplesQuery:
         pass
 
+    def has(self, property: Union[QueryFeature, str, pd.Series], kind=None) -> SamplesQuery:
+        return self.hasa(property=property, kind=kind)
+
     @abc.abstractmethod
     def complement(self):
         pass
+    #
+    # @abc.abstractmethod
+    # def within(self, sample_names: Union[str, List[str]], kind: str = 'distance', **kwargs) -> SamplesQuery:
+    #     return self.isin(sample_names=sample_names, kind='distance')
 
     @abc.abstractmethod
-    def within(self, sample_names: Union[str, List[str]], kind: str = 'distance', **kwargs) -> SamplesQuery:
-        pass
-
-    @abc.abstractmethod
-    def is_type(self, sample_type) -> SamplesQuery:
+    def isin(self, sample_names: Union[str, List[str]], kind: str = 'distance', **kwargs) -> SamplesQuery:
         pass
 
     @abc.abstractmethod

--- a/genomics_data_index/api/query/SamplesQuery.py
+++ b/genomics_data_index/api/query/SamplesQuery.py
@@ -74,15 +74,25 @@ class SamplesQuery(abc.ABC):
         pass
 
     def has(self, property: Union[QueryFeature, str, pd.Series], kind=None) -> SamplesQuery:
+        """
+        Queries for samples that have a particular property. Synonym for hasa().
+        """
         return self.hasa(property=property, kind=kind)
 
     @abc.abstractmethod
     def complement(self):
         pass
-    #
-    # @abc.abstractmethod
-    # def within(self, sample_names: Union[str, List[str]], kind: str = 'distance', **kwargs) -> SamplesQuery:
-    #     return self.isin(sample_names=sample_names, kind='distance')
+
+    def within(self, data: Union[str, List[str]], **kwargs) -> SamplesQuery:
+        """
+        Queries for samples within a particular distance. This is identical to calling
+        isin(data, kind='distance', ...). Used to help make code easier to read.
+
+        :param data: The data to use for selecting samples by.
+        :param **kwargs: Other arguments for the the internal implementations.
+        :return: A SamplesQuery which selects only those samples matching the given criteria from the current query.
+        """
+        return self.isin(data=data, kind='distance', **kwargs)
 
     @abc.abstractmethod
     def isin(self, data: Union[str, List[str]], kind: str = 'names', **kwargs) -> SamplesQuery:

--- a/genomics_data_index/api/query/SamplesQuery.py
+++ b/genomics_data_index/api/query/SamplesQuery.py
@@ -90,9 +90,31 @@ class SamplesQuery(abc.ABC):
 
         :param data: The data to use for selecting samples by.
         :param **kwargs: Other arguments for the the internal implementations.
-        :return: A SamplesQuery which selects only those samples matching the given criteria from the current query.
+        :return: A SamplesQuery with the matched samples.
         """
         return self.isin(data=data, kind='distance', **kwargs)
+
+    @abc.abstractmethod
+    def isa(self, data: Union[str, List[str]], kind: str = 'names', **kwargs) -> SamplesQuery:
+        """
+        Queries for samples which are a particular type/belong to a particular category.
+        Read as "subset samples which are a (isa) particular type defined by 'data'".
+        The default implementation will select samples by sample name but this is useful when used
+        with an attached dataframe (at which point it selects based on matches to a column,
+        see documentation for DataFrameSamplesQuery).
+
+        :param data: The data to match.
+        :param kind: The particular kind of data passed.
+        :**kwargs: Arguments for the underlying implementation.
+        :return: A SamplesQuery with the matched samples.
+        """
+        pass
+
+    def isan(self, data: Union[str, List[str]], kind: str = 'names', **kwargs) -> SamplesQuery:
+        """
+        Synonym for isa()
+        """
+        return self.isa(data=data, kind=kind, **kwargs)
 
     @abc.abstractmethod
     def isin(self, data: Union[str, List[str], pd.Series], kind: str = 'names', **kwargs) -> SamplesQuery:

--- a/genomics_data_index/api/query/SamplesQuery.py
+++ b/genomics_data_index/api/query/SamplesQuery.py
@@ -95,7 +95,7 @@ class SamplesQuery(abc.ABC):
         return self.isin(data=data, kind='distance', **kwargs)
 
     @abc.abstractmethod
-    def isin(self, data: Union[str, List[str]], kind: str = 'names', **kwargs) -> SamplesQuery:
+    def isin(self, data: Union[str, List[str], pd.Series], kind: str = 'names', **kwargs) -> SamplesQuery:
         pass
 
     @abc.abstractmethod

--- a/genomics_data_index/api/query/impl/DataFrameSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/DataFrameSamplesQuery.py
@@ -23,7 +23,7 @@ class DataFrameSamplesQuery(WrappedSamplesQuery):
         self._sample_ids_col = sample_ids_col
         self._data_frame = data_frame
 
-    def has(self, property: Union[QueryFeature, str, pd.Series], kind=None) -> SamplesQuery:
+    def hasa(self, property: Union[QueryFeature, str, pd.Series], kind=None) -> SamplesQuery:
         if kind == 'dataframe':
             if isinstance(property, pd.Series) and property.dtype == bool:
                 if property.index.equals(self._data_frame.index):
@@ -35,7 +35,7 @@ class DataFrameSamplesQuery(WrappedSamplesQuery):
                 raise Exception(f'property=[{property}] is wrong type for kind=[{kind}]. '
                                 f'Must be a boolean pandas.Series')
         else:
-            return self._wrap_create(self._wrapped_query.has(property=property, kind=kind))
+            return self._wrap_create(self._wrapped_query.hasa(property=property, kind=kind))
 
     def _get_has_kinds(self) -> List[str]:
         return self._wrapped_query._get_has_kinds() + self.HAS_KINDS
@@ -43,7 +43,7 @@ class DataFrameSamplesQuery(WrappedSamplesQuery):
     def _handle_select_by_series(self, series_selection: pd.Series) -> SamplesQuery:
         subset_df = self._data_frame[series_selection]
         subset_sample_set = SampleSet(subset_df[self._sample_ids_col].tolist())
-        query_message = 'has(subset from series)'
+        query_message = 'hasa(subset from series)'
         subset_query = self._wrapped_query.intersect(sample_set=subset_sample_set, query_message=query_message)
         return self._wrap_create(subset_query)
 

--- a/genomics_data_index/api/query/impl/DataFrameSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/DataFrameSamplesQuery.py
@@ -37,6 +37,12 @@ class DataFrameSamplesQuery(WrappedSamplesQuery):
         else:
             return self._wrap_create(self._wrapped_query.hasa(property=property, kind=kind))
 
+    def _isin_internal(self, data: Union[str, List[str]], kind, **kwargs) -> SamplesQuery:
+        return super()._isin_internal(data=data, kind=kind, **kwargs)
+
+    def _isin_kinds(self) -> List[str]:
+        return super()._isin_kinds()
+
     def _get_has_kinds(self) -> List[str]:
         return self._wrapped_query._get_has_kinds() + self.HAS_KINDS
 

--- a/genomics_data_index/api/query/impl/DataFrameSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/DataFrameSamplesQuery.py
@@ -38,7 +38,7 @@ class DataFrameSamplesQuery(WrappedSamplesQuery):
             return self._wrap_create(self._wrapped_query.hasa(property=property, kind=kind))
 
     def _isin_internal(self, data: Union[str, List[str]], kind, **kwargs) -> SamplesQuery:
-        return super()._isin_internal(data=data, kind=kind, **kwargs)
+        return self._wrap_create(self._wrapped_query.isin(data))
 
     def _isin_kinds(self) -> List[str]:
         return super()._isin_kinds()

--- a/genomics_data_index/api/query/impl/DataFrameSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/DataFrameSamplesQuery.py
@@ -19,10 +19,14 @@ class DataFrameSamplesQuery(WrappedSamplesQuery):
     def __init__(self, connection: DataIndexConnection, wrapped_query: SamplesQuery,
                  universe_set: SampleSet,
                  data_frame: pd.DataFrame,
-                 sample_ids_col: str):
+                 sample_ids_col: str,
+                 default_isa_kind: str,
+                 default_isa_column: str):
         super().__init__(connection=connection, wrapped_query=wrapped_query, universe_set=universe_set)
         self._sample_ids_col = sample_ids_col
         self._data_frame = data_frame
+        self._default_isa_kind = default_isa_kind
+        self._default_isa_column = default_isa_column
 
     def _isin_internal(self, data: Union[str, List[str], pd.Series], kind: str, **kwargs) -> SamplesQuery:
         if kind == 'dataframe':
@@ -39,13 +43,27 @@ class DataFrameSamplesQuery(WrappedSamplesQuery):
     def _isin_kinds(self) -> List[str]:
         return super()._isin_kinds() + self.ISIN_KINDS
 
+    def isa(self, data: Union[str, List[str]], kind: str = None, **kwargs) -> SamplesQuery:
+        if kind is None:
+            if self._default_isa_kind is None:
+                kind = 'names'
+            else:
+                kind = self._default_isa_kind
+
+        if kind == 'names':
+            return self._wrap_create(self._wrapped_query.isa(data=data, kind=kind, **kwargs))
+        else:
+            return self._isa_internal(data=data, kind=kind, **kwargs)
+
     def _isa_internal(self, data: Union[str, List[str]], kind: str, isa_column: str = None) -> SamplesQuery:
         if kind == 'dataframe':
-            if isa_column is None:
+            if isa_column is None and self._default_isa_column is not None:
+                isa_column = self._default_isa_column
+            elif isa_column is None:
                 raise Exception(f'No defined isa_column, cannot execute isa for kind={kind}')
-            else:
-                return self._handle_select_by_series(self._data_frame[isa_column] == data,
-                                                     query_message=f"isa('{isa_column}' is '{data}')")
+
+            return self._handle_select_by_series(self._data_frame[isa_column] == data,
+                                                 query_message=f"isa('{isa_column}' is '{data}')")
         else:
             raise Exception(f'Invalid kind={kind}. Must be one of {self._isa_kinds()}')
 
@@ -71,16 +89,25 @@ class DataFrameSamplesQuery(WrappedSamplesQuery):
                                      wrapped_query=wrapped_query,
                                      data_frame=self._data_frame,
                                      sample_ids_col=self._sample_ids_col,
-                                     universe_set=self.universe_set)
+                                     universe_set=self.universe_set,
+                                     default_isa_kind=self._default_isa_kind,
+                                     default_isa_column=self._default_isa_column)
 
     def build_tree(self, kind: str, scope: str, **kwargs) -> SamplesQuery:
         return TreeSamplesQuery.create(kind=kind, scope=scope, database_connection=self._query_connection,
                                        wrapped_query=self, **kwargs)
 
+    def join(self, data_frame: pd.DataFrame, sample_ids_column: str = None,
+             sample_names_column: str = None, default_isa_kind: str = 'names',
+             default_isa_column: str = None) -> SamplesQuery:
+        raise Exception(f'Cannot join a new dataframe onto an existing data frame query: {self}')
+
     @classmethod
     def create_with_sample_ids_column(self, sample_ids_column: str, data_frame: pd.DataFrame,
                                       wrapped_query: SamplesQuery, connection: DataIndexConnection,
-                                      query_message: str = None) -> DataFrameSamplesQuery:
+                                      query_message: str = None,
+                                      default_isa_kind: str = None,
+                                      default_isa_column: str = None) -> DataFrameSamplesQuery:
         sample_ids = data_frame[sample_ids_column].tolist()
         df_sample_set = SampleSet(sample_ids=sample_ids)
         universe_set = wrapped_query.universe_set.intersection(df_sample_set)
@@ -95,16 +122,16 @@ class DataFrameSamplesQuery(WrappedSamplesQuery):
                                      wrapped_query=wrapped_query_intersect,
                                      universe_set=universe_set,
                                      data_frame=data_frame,
-                                     sample_ids_col=sample_ids_column)
-
-    def join(self, data_frame: pd.DataFrame, sample_ids_column: str = None,
-             sample_names_column: str = None) -> SamplesQuery:
-        raise Exception(f'Cannot join a new dataframe onto an existing data frame query: {self}')
+                                     sample_ids_col=sample_ids_column,
+                                     default_isa_column=default_isa_column,
+                                     default_isa_kind=default_isa_kind)
 
     @classmethod
     def create_with_sample_names_column(self, sample_names_column: str, data_frame: pd.DataFrame,
                                         wrapped_query: SamplesQuery,
-                                        connection: DataIndexConnection) -> DataFrameSamplesQuery:
+                                        connection: DataIndexConnection,
+                                        default_isa_kind: str = None,
+                                        default_isa_column: str = None) -> DataFrameSamplesQuery:
         sample_names = set(data_frame[sample_names_column].tolist())
         sample_ids_column = 'Sample ID'
 
@@ -125,4 +152,6 @@ class DataFrameSamplesQuery(WrappedSamplesQuery):
                                                                    data_frame=data_frame,
                                                                    wrapped_query=wrapped_query,
                                                                    connection=connection,
-                                                                   query_message=query_message)
+                                                                   query_message=query_message,
+                                                                   default_isa_column=default_isa_column,
+                                                                   default_isa_kind=default_isa_kind)

--- a/genomics_data_index/api/query/impl/DataFrameSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/DataFrameSamplesQuery.py
@@ -55,15 +55,20 @@ class DataFrameSamplesQuery(WrappedSamplesQuery):
         else:
             return self._isa_internal(data=data, kind=kind, **kwargs)
 
-    def _isa_internal(self, data: Union[str, List[str]], kind: str, isa_column: str = None) -> SamplesQuery:
+    def _isa_internal(self, data: Union[str, List[str]], kind: str, isa_column: str = None,
+                      regex: bool = False) -> SamplesQuery:
         if kind == 'dataframe':
             if isa_column is None and self._default_isa_column is not None:
                 isa_column = self._default_isa_column
             elif isa_column is None:
                 raise Exception(f'No defined isa_column, cannot execute isa for kind={kind}')
 
-            return self._handle_select_by_series(self._data_frame[isa_column] == data,
-                                                 query_message=f"isa('{isa_column}' is '{data}')")
+            if regex:
+                return self._handle_select_by_series(self._data_frame[isa_column].str.contains(data),
+                                                     query_message=f"isa('{isa_column}' contains '{data}')")
+            else:
+                return self._handle_select_by_series(self._data_frame[isa_column] == data,
+                                                     query_message=f"isa('{isa_column}' is '{data}')")
         else:
             raise Exception(f'Invalid kind={kind}. Must be one of {self._isa_kinds()}')
 

--- a/genomics_data_index/api/query/impl/SamplesQueryIndex.py
+++ b/genomics_data_index/api/query/impl/SamplesQueryIndex.py
@@ -176,7 +176,7 @@ class SamplesQueryIndex(SamplesQuery):
     def __repr__(self) -> str:
         return str(self)
 
-    def has(self, property: Union[QueryFeature, str, pd.Series], kind=None) -> SamplesQuery:
+    def hasa(self, property: Union[QueryFeature, str, pd.Series], kind=None) -> SamplesQuery:
         if isinstance(property, QueryFeature):
             query_feature = property
         elif isinstance(property, pd.Series):

--- a/genomics_data_index/api/query/impl/SamplesQueryIndex.py
+++ b/genomics_data_index/api/query/impl/SamplesQueryIndex.py
@@ -203,7 +203,7 @@ class SamplesQueryIndex(SamplesQuery):
         return self._create_from(self._query_connection, intersect_found,
                                  queries_collection=queries_collection)
 
-    def within(self, sample_names: Union[str, List[str]], kind: str = 'distance', **kwargs) -> SamplesQuery:
+    def isin(self, sample_names: Union[str, List[str]], kind: str = 'distance', **kwargs) -> SamplesQuery:
         raise Exception(f'Cannot query within a distance without a tree.'
                         f' Perhaps you want to run build_tree() first to build a tree.')
 

--- a/genomics_data_index/api/query/impl/SamplesQueryIndex.py
+++ b/genomics_data_index/api/query/impl/SamplesQueryIndex.py
@@ -41,19 +41,24 @@ class SamplesQueryIndex(SamplesQuery):
         return self._sample_set
 
     def join(self, data_frame: pd.DataFrame, sample_ids_column: str = None,
-             sample_names_column: str = None) -> SamplesQuery:
+             sample_names_column: str = None, default_isa_kind: str = 'names',
+             default_isa_column: str = None) -> SamplesQuery:
         if sample_ids_column is None and sample_names_column is None:
             raise Exception('At least one of sample_ids_column or sample_names_column must be set.')
         elif sample_ids_column is not None:
             return DataFrameSamplesQuery.create_with_sample_ids_column(sample_ids_column=sample_ids_column,
                                                                        data_frame=data_frame,
                                                                        wrapped_query=self,
-                                                                       connection=self._query_connection)
+                                                                       connection=self._query_connection,
+                                                                       default_isa_kind=default_isa_kind,
+                                                                       default_isa_column=default_isa_column)
         else:
             return DataFrameSamplesQuery.create_with_sample_names_column(sample_names_column=sample_names_column,
                                                                          data_frame=data_frame,
                                                                          wrapped_query=self,
-                                                                         connection=self._query_connection)
+                                                                         connection=self._query_connection,
+                                                                         default_isa_kind=default_isa_kind,
+                                                                         default_isa_column=default_isa_column)
 
     def intersect(self, sample_set: SampleSet, query_message: str = None) -> SamplesQuery:
         intersected_set = self._intersect_sample_set(sample_set)

--- a/genomics_data_index/api/query/impl/TreeSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/TreeSamplesQuery.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 from typing import Union, List
+import pandas as pd
 
 from ete3 import Tree, TreeStyle
 
@@ -100,7 +101,7 @@ class TreeSamplesQuery(WrappedSamplesQuery):
         found_samples = SampleSet(found_samples_list)
         return self.intersect(found_samples, f'within(mrca of {sample_names})')
 
-    def _isin_internal(self, data: Union[str, List[str]], kind, **kwargs) -> SamplesQuery:
+    def _isin_internal(self, data: Union[str, List[str], pd.Series], kind, **kwargs) -> SamplesQuery:
         if kind == 'distance':
             return self._within_distance(sample_names=data, kind=kind, **kwargs)
         elif kind == 'mrca':

--- a/genomics_data_index/api/query/impl/TreeSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/TreeSamplesQuery.py
@@ -101,7 +101,7 @@ class TreeSamplesQuery(WrappedSamplesQuery):
         found_samples = SampleSet(found_samples_list)
         return self.intersect(found_samples, f'within(mrca of {sample_names})')
 
-    def _isin_internal(self, data: Union[str, List[str], pd.Series], kind, **kwargs) -> SamplesQuery:
+    def _isin_internal(self, data: Union[str, List[str], pd.Series], kind: str, **kwargs) -> SamplesQuery:
         if kind == 'distance':
             return self._within_distance(sample_names=data, kind=kind, **kwargs)
         elif kind == 'mrca':

--- a/genomics_data_index/api/query/impl/TreeSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/TreeSamplesQuery.py
@@ -16,7 +16,7 @@ from genomics_data_index.storage.SampleSet import SampleSet
 class TreeSamplesQuery(WrappedSamplesQuery):
     BUILD_TREE_KINDS = ['mutation']
     DISTANCE_UNITS = ['substitutions', 'substitutions/site']
-    WITHIN_TYPES = ['distance', 'mrca']
+    ISIN_TREE_TYPES = ['distance', 'mrca']
 
     def __init__(self, connection: DataIndexConnection, wrapped_query: SamplesQuery, tree: Tree,
                  alignment_length: int):
@@ -100,13 +100,16 @@ class TreeSamplesQuery(WrappedSamplesQuery):
         found_samples = SampleSet(found_samples_list)
         return self.intersect(found_samples, f'within(mrca of {sample_names})')
 
-    def isin(self, sample_names: Union[str, List[str]], kind: str = 'distance', **kwargs) -> SamplesQuery:
+    def _isin_internal(self, data: Union[str, List[str]], kind, **kwargs) -> SamplesQuery:
         if kind == 'distance':
-            return self._within_distance(sample_names=sample_names, kind=kind, **kwargs)
+            return self._within_distance(sample_names=data, kind=kind, **kwargs)
         elif kind == 'mrca':
-            return self._within_mrca(sample_names=sample_names)
+            return self._within_mrca(sample_names=data)
         else:
-            raise Exception(f'kind=[{kind}] is not supported. Must be one of {self.WITHIN_TYPES}')
+            raise Exception(f'kind=[{kind}] is not supported. Must be one of {self._isin_kinds()}')
+
+    def _isin_kinds(self) -> List[str]:
+        return super()._isin_kinds() + self.ISIN_TREE_TYPES
 
     def tree_styler(self, initial_style: TreeStyle = TreeStyle()) -> TreeStyler:
         return TreeStyler(tree=copy.deepcopy(self._tree),

--- a/genomics_data_index/api/query/impl/TreeSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/TreeSamplesQuery.py
@@ -100,7 +100,7 @@ class TreeSamplesQuery(WrappedSamplesQuery):
         found_samples = SampleSet(found_samples_list)
         return self.intersect(found_samples, f'within(mrca of {sample_names})')
 
-    def within(self, sample_names: Union[str, List[str]], kind: str = 'distance', **kwargs) -> SamplesQuery:
+    def isin(self, sample_names: Union[str, List[str]], kind: str = 'distance', **kwargs) -> SamplesQuery:
         if kind == 'distance':
             return self._within_distance(sample_names=sample_names, kind=kind, **kwargs)
         elif kind == 'mrca':

--- a/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
@@ -85,18 +85,29 @@ class WrappedSamplesQuery(SamplesQuery, abc.ABC):
         raise Exception(f'No tree exists for {self.__class__}.'
                         f' Perhaps you should try to run build_tree() first to build a tree.')
 
-    @abc.abstractmethod
-    def _isin_internal(self, data: Union[str, List[str], pd.Series], kind, **kwargs) -> SamplesQuery:
-        pass
+    def _isin_internal(self, data: Union[str, List[str], pd.Series], kind: str, **kwargs) -> SamplesQuery:
+        raise Exception(f'Invalid kind={kind}. Must be one of {self._isin_kinds()}')
+
+    def _isa_internal(self, data: Union[str, List[str]], kind: str, **kwargs) -> SamplesQuery:
+        raise Exception(f'Invalid kind={kind}. Must be one of {self._isa_kinds()}')
 
     def _isin_kinds(self) -> List[str]:
         return ['names']
 
     def isin(self, data: Union[str, List[str], pd.Series], kind: str = 'names', **kwargs) -> SamplesQuery:
         if kind == 'names':
-            return self._wrap_create(self._wrapped_query.isin(data))
+            return self._wrap_create(self._wrapped_query.isin(data=data, kind=kind, **kwargs))
         else:
             return self._isin_internal(data=data, kind=kind, **kwargs)
+
+    def _isa_kinds(self) -> List[str]:
+        return ['names']
+
+    def isa(self, data: Union[str, List[str]], kind: str = 'names', **kwargs) -> SamplesQuery:
+        if kind == 'names':
+            return self._wrap_create(self._wrapped_query.isa(data=data, kind=kind, **kwargs))
+        else:
+            return self._isa_internal(data=data, kind=kind, **kwargs)
 
     def __and__(self, other):
         return self.and_(other)

--- a/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
@@ -86,13 +86,13 @@ class WrappedSamplesQuery(SamplesQuery, abc.ABC):
                         f' Perhaps you should try to run build_tree() first to build a tree.')
 
     @abc.abstractmethod
-    def _isin_internal(self, data: Union[str, List[str]], kind, **kwargs) -> SamplesQuery:
+    def _isin_internal(self, data: Union[str, List[str], pd.Series], kind, **kwargs) -> SamplesQuery:
         pass
 
     def _isin_kinds(self) -> List[str]:
         return ['names']
 
-    def isin(self, data: Union[str, List[str]], kind: str = 'names', **kwargs) -> SamplesQuery:
+    def isin(self, data: Union[str, List[str], pd.Series], kind: str = 'names', **kwargs) -> SamplesQuery:
         if kind == 'names':
             return self._wrap_create(self._wrapped_query.isin(data))
         else:

--- a/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
@@ -58,8 +58,8 @@ class WrappedSamplesQuery(SamplesQuery, abc.ABC):
     def and_(self, other: SamplesQuery) -> SamplesQuery:
         return self._wrap_create(self._wrapped_query.and_(other))
 
-    def has(self, property: Union[QueryFeature, str, pd.Series], kind=None) -> SamplesQuery:
-        return self._wrap_create(self._wrapped_query.has(property=property, kind=kind))
+    def hasa(self, property: Union[QueryFeature, str, pd.Series], kind=None) -> SamplesQuery:
+        return self._wrap_create(self._wrapped_query.hasa(property=property, kind=kind))
 
     def _get_has_kinds(self) -> List[str]:
         return self._wrapped_query._get_has_kinds()

--- a/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
@@ -88,7 +88,7 @@ class WrappedSamplesQuery(SamplesQuery, abc.ABC):
         raise Exception(f'No tree exists for {self.__class__}.'
                         f' Perhaps you should try to run build_tree() first to build a tree.')
 
-    def within(self, sample_names: Union[str, List[str]], kind: str = 'distance', **kwargs) -> SamplesQuery:
+    def isin(self, sample_names: Union[str, List[str]], kind: str = 'distance', **kwargs) -> SamplesQuery:
         raise Exception(f'Cannot query within a distance without a tree.'
                         f' Perhaps you want to run build_tree() first to build a tree.')
 

--- a/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
@@ -35,9 +35,12 @@ class WrappedSamplesQuery(SamplesQuery, abc.ABC):
         return self._wrap_create(intersected_query)
 
     def join(self, data_frame: pd.DataFrame, sample_ids_column: str = None,
-             sample_names_column: str = None) -> SamplesQuery:
+             sample_names_column: str = None, default_isa_kind: str = 'names',
+             default_isa_column: str = None) -> SamplesQuery:
         return self._wrap_create(self._wrapped_query.join(data_frame=data_frame, sample_ids_column=sample_ids_column,
-                                                          sample_names_column=sample_names_column))
+                                                          sample_names_column=sample_names_column,
+                                                          default_isa_kind=default_isa_kind,
+                                                          default_isa_column=default_isa_column))
 
     @abc.abstractmethod
     def _wrap_create(self, wrapped_query: SamplesQuery) -> WrappedSamplesQuery:

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_from_project.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_from_project.py
@@ -9,7 +9,7 @@ def test_query_single_mutation(loaded_data_store_from_project_dir: GenomicsDataI
     db = ds.connection.database
     sampleB = db.get_session().query(Sample).filter(Sample.name == 'SampleB').one()
 
-    query_result = ds.samples_query().has(QueryFeatureMutation('reference:5061:G:A'))
+    query_result = ds.samples_query().hasa(QueryFeatureMutation('reference:5061:G:A'))
     assert 1 == len(query_result)
     assert {sampleB.id} == set(query_result.sample_set)
     assert 9 == len(query_result.universe_set)
@@ -20,8 +20,8 @@ def test_query_chained_mlst_alleles(loaded_data_store_from_project_dir: Genomics
     db = ds.connection.database
     sample1 = db.get_session().query(Sample).filter(Sample.name == 'CFSAN002349').one()
 
-    query_result = ds.samples_query().has(
-        QueryFeatureMLST('lmonocytogenes:abcZ:1')).has(
+    query_result = ds.samples_query().hasa(
+        QueryFeatureMLST('lmonocytogenes:abcZ:1')).hasa(
         QueryFeatureMLST('lmonocytogenes:lhkA:4'))
     assert 1 == len(query_result)
     assert {sample1.id} == set(query_result.sample_set)

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
@@ -538,7 +538,7 @@ def test_query_then_join_dataframe_single_query(loaded_database_connection: Data
     assert ['green', 'blue'] == df['Color'].tolist()
 
 
-def test_query_join_dataframe_has_dataframe_column(loaded_database_connection: DataIndexConnection):
+def test_query_join_dataframe_isin_dataframe_column(loaded_database_connection: DataIndexConnection):
     db = loaded_database_connection.database
     sampleA = db.get_session().query(Sample).filter(Sample.name == 'SampleA').one()
     sampleB = db.get_session().query(Sample).filter(Sample.name == 'SampleB').one()
@@ -555,7 +555,7 @@ def test_query_join_dataframe_has_dataframe_column(loaded_database_connection: D
     assert 3 == len(query_result)
     assert 3 == len(query_result.universe_set)
 
-    query_result = query_result.hasa(property=(metadata_df['Color'] == 'red'), kind='dataframe')
+    query_result = query_result.isin(metadata_df['Color'] == 'red', kind='dataframe')
 
     assert 1 == len(query_result)
     assert 3 == len(query_result.universe_set)
@@ -563,7 +563,7 @@ def test_query_join_dataframe_has_dataframe_column(loaded_database_connection: D
     df = query_result.toframe()
 
     assert ['SampleA'] == df['Sample Name'].tolist()
-    assert {'dataframe(ids_col=[Sample ID]) AND hasa(subset from series)'} == set(df['Query'].tolist())
+    assert {'dataframe(ids_col=[Sample ID]) AND isin(subset from series)'} == set(df['Query'].tolist())
 
 
 def test_query_join_dataframe_has_dataframe_column_select_two_samples(loaded_database_connection: DataIndexConnection):
@@ -583,7 +583,7 @@ def test_query_join_dataframe_has_dataframe_column_select_two_samples(loaded_dat
     assert 3 == len(query_result)
     assert 3 == len(query_result.universe_set)
 
-    query_result = query_result.hasa(property=(metadata_df['Color'] == 'red'), kind='dataframe')
+    query_result = query_result.isin(metadata_df['Color'] == 'red', kind='dataframe')
 
     assert 2 == len(query_result)
     assert 3 == len(query_result.universe_set)
@@ -592,7 +592,7 @@ def test_query_join_dataframe_has_dataframe_column_select_two_samples(loaded_dat
 
     df = df.sort_values(['Sample Name'])
     assert ['SampleA', 'SampleB'] == df['Sample Name'].tolist()
-    assert {'dataframe(ids_col=[Sample ID]) AND hasa(subset from series)'} == set(df['Query'].tolist())
+    assert {'dataframe(ids_col=[Sample ID]) AND isin(subset from series)'} == set(df['Query'].tolist())
 
 
 def test_query_join_dataframe_has_dataframe_column_invalid_series_index(
@@ -613,7 +613,7 @@ def test_query_join_dataframe_has_dataframe_column_invalid_series_index(
     query_result = query(loaded_database_connection).join(data_frame=metadata_df, sample_ids_column='Sample ID')
 
     with pytest.raises(Exception) as execinfo:
-        query_result.hasa(property=invalid_series_select, kind='dataframe')
+        query_result.isin(data=invalid_series_select, kind='dataframe')
     assert 'does not have same index as internal data frame' in str(execinfo.value)
 
 

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
@@ -598,6 +598,21 @@ def test_query_join_dataframe_isa_dataframe_column(loaded_database_connection: D
     assert ['SampleA'] == df['Sample Name'].tolist()
     assert {"dataframe(ids_col=[Sample ID]) AND isa('Color' is 'red')"} == set(df['Query'].tolist())
 
+    # Setting regex=True should let me pass regexes
+    sub_result = query_result.isa(r'^re', regex=True)
+    assert 1 == len(sub_result)
+    assert 3 == len(sub_result.universe_set)
+    assert {sampleA.id} == set(sub_result.sample_set)
+
+    df = sub_result.toframe()
+    assert ['SampleA'] == df['Sample Name'].tolist()
+    assert {"dataframe(ids_col=[Sample ID]) AND isa('Color' contains '^re')"} == set(df['Query'].tolist())
+
+    # Nothing should match this below regex
+    sub_result = query_result.isa(r'^ed', regex=True)
+    assert 0 == len(sub_result)
+    assert 3 == len(sub_result.universe_set)
+
 
 def test_query_join_dataframe_isin_dataframe_column(loaded_database_connection: DataIndexConnection):
     db = loaded_database_connection.database

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
@@ -734,6 +734,14 @@ def test_within_constructed_tree(loaded_database_connection: DataIndexConnection
     assert {'reference:839:C:G AND mutation_tree(genome) AND within(0.005 substitutions/site of SampleC)'
             } == set(df['Query'].tolist())
 
+    # subs/site using within
+    df = query_result.within('SampleC', distance=0.005, units='substitutions/site').toframe().sort_values('Sample Name')
+    assert 2 == len(df)
+    assert ['Query', 'Sample Name', 'Sample ID', 'Status'] == df.columns.tolist()
+    assert ['SampleB', 'SampleC'] == df['Sample Name'].tolist()
+    assert {'reference:839:C:G AND mutation_tree(genome) AND within(0.005 substitutions/site of SampleC)'
+            } == set(df['Query'].tolist())
+
     # subs
     df = query_result.isin('SampleC', kind='distance', distance=26, units='substitutions').toframe().sort_values('Sample Name')
     assert 2 == len(df)

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
@@ -671,7 +671,7 @@ def test_query_then_build_tree_then_join_dataframe(loaded_database_connection: D
     assert ['green', 'blue'] == df['Color'].tolist()
 
     # I should still be able to perform within queries since I have a tree attached
-    query_result = query_result.within(['SampleB'], kind='mrca')
+    query_result = query_result.isin(['SampleB'], kind='mrca')
 
     assert 1 == len(query_result)
     assert 3 == len(query_result.universe_set)
@@ -685,7 +685,7 @@ def test_within_constructed_tree(loaded_database_connection: DataIndexConnection
     assert 2 == len(query_result)
 
     # subs/site
-    df = query_result.within('SampleC', distance=0.005, units='substitutions/site').toframe().sort_values('Sample Name')
+    df = query_result.isin('SampleC', distance=0.005, units='substitutions/site').toframe().sort_values('Sample Name')
     assert 2 == len(df)
     assert ['Query', 'Sample Name', 'Sample ID', 'Status'] == df.columns.tolist()
     assert ['SampleB', 'SampleC'] == df['Sample Name'].tolist()
@@ -693,28 +693,28 @@ def test_within_constructed_tree(loaded_database_connection: DataIndexConnection
             } == set(df['Query'].tolist())
 
     # subs
-    df = query_result.within('SampleC', distance=26, units='substitutions').toframe().sort_values('Sample Name')
+    df = query_result.isin('SampleC', distance=26, units='substitutions').toframe().sort_values('Sample Name')
     assert 2 == len(df)
     assert ['SampleB', 'SampleC'] == df['Sample Name'].tolist()
     assert {'reference:839:C:G AND mutation_tree(genome) AND within(26 substitutions of SampleC)'
             } == set(df['Query'].tolist())
 
     # should not include reference genome
-    df = query_result.within('SampleC', distance=100, units='substitutions').toframe().sort_values('Sample Name')
+    df = query_result.isin('SampleC', distance=100, units='substitutions').toframe().sort_values('Sample Name')
     assert 2 == len(df)
     assert ['SampleB', 'SampleC'] == df['Sample Name'].tolist()
     assert {'reference:839:C:G AND mutation_tree(genome) AND within(100 substitutions of SampleC)'
             } == set(df['Query'].tolist())
 
     # should have only query sample
-    df = query_result.within('SampleC', distance=1, units='substitutions').toframe().sort_values('Sample Name')
+    df = query_result.isin('SampleC', distance=1, units='substitutions').toframe().sort_values('Sample Name')
     assert 1 == len(df)
     assert ['SampleC'] == df['Sample Name'].tolist()
     assert {'reference:839:C:G AND mutation_tree(genome) AND within(1 substitutions of SampleC)'
             } == set(df['Query'].tolist())
 
     # mrca
-    df = query_result.within(['SampleB', 'SampleC'], kind='mrca').toframe().sort_values('Sample Name')
+    df = query_result.isin(['SampleB', 'SampleC'], kind='mrca').toframe().sort_values('Sample Name')
     assert 2 == len(df)
     assert ['Query', 'Sample Name', 'Sample ID', 'Status'] == df.columns.tolist()
     assert ['SampleB', 'SampleC'] == df['Sample Name'].tolist()
@@ -729,7 +729,7 @@ def test_within_constructed_tree_larger_tree(loaded_database_connection: DataInd
     assert 3 == len(query_result)
 
     # mrca B and C
-    df = query_result.within(['SampleB', 'SampleC'], kind='mrca').toframe().sort_values('Sample Name')
+    df = query_result.isin(['SampleB', 'SampleC'], kind='mrca').toframe().sort_values('Sample Name')
     assert 2 == len(df)
     assert ['Query', 'Sample Name', 'Sample ID', 'Status'] == df.columns.tolist()
     assert ['SampleB', 'SampleC'] == df['Sample Name'].tolist()
@@ -737,7 +737,7 @@ def test_within_constructed_tree_larger_tree(loaded_database_connection: DataInd
             } == set(df['Query'].tolist())
 
     # mrca A and B
-    df = query_result.within(['SampleA', 'SampleC'], kind='mrca').toframe().sort_values('Sample Name')
+    df = query_result.isin(['SampleA', 'SampleC'], kind='mrca').toframe().sort_values('Sample Name')
     assert 3 == len(df)
     assert ['Query', 'Sample Name', 'Sample ID', 'Status'] == df.columns.tolist()
     assert ['SampleA', 'SampleB', 'SampleC'] == df['Sample Name'].tolist()

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
@@ -46,7 +46,7 @@ def test_query_single_mutation(loaded_database_connection: DataIndexConnection):
     db = loaded_database_connection.database
     sampleB = db.get_session().query(Sample).filter(Sample.name == 'SampleB').one()
 
-    query_result = query(loaded_database_connection).has(QueryFeatureMutation('reference:5061:G:A'))
+    query_result = query(loaded_database_connection).hasa(QueryFeatureMutation('reference:5061:G:A'))
     assert 1 == len(query_result)
     assert {sampleB.id} == set(query_result.sample_set)
     assert 9 == len(query_result.universe_set)
@@ -56,7 +56,7 @@ def test_query_single_mutation_complement(loaded_database_connection: DataIndexC
     db = loaded_database_connection.database
     sampleB = db.get_session().query(Sample).filter(Sample.name == 'SampleB').one()
 
-    query_result = query(loaded_database_connection).has(QueryFeatureMutation('reference:5061:G:A'))
+    query_result = query(loaded_database_connection).hasa(QueryFeatureMutation('reference:5061:G:A'))
     assert 1 == len(query_result)
     assert {sampleB.id} == set(query_result.sample_set)
     assert 9 == len(query_result.universe_set)
@@ -81,7 +81,7 @@ def test_query_single_mutation_complement(loaded_database_connection: DataIndexC
 
 
 def test_query_single_mutation_summary(loaded_database_connection: DataIndexConnection):
-    df = query(loaded_database_connection).has('reference:5061:G:A', kind='mutation').summary()
+    df = query(loaded_database_connection).hasa('reference:5061:G:A', kind='mutation').summary()
     assert 1 == len(df)
     assert ['Query', 'Present', 'Absent', 'Unknown', 'Total',
             '% Present', '% Absent', '% Unknown'] == df.columns.tolist()
@@ -100,7 +100,7 @@ def test_query_single_mutation_two_samples(loaded_database_connection: DataIndex
     sampleB = db.get_session().query(Sample).filter(Sample.name == 'SampleB').one()
     sampleC = db.get_session().query(Sample).filter(Sample.name == 'SampleC').one()
 
-    query_result = query(loaded_database_connection).has(QueryFeatureMutation('reference:839:C:G'))
+    query_result = query(loaded_database_connection).hasa(QueryFeatureMutation('reference:839:C:G'))
     assert 2 == len(query_result)
     assert {sampleB.id, sampleC.id} == set(query_result.sample_set)
     assert 9 == len(query_result.universe_set)
@@ -112,7 +112,7 @@ def test_query_single_mutation_two_samples_complement(loaded_database_connection
     sampleB = db.get_session().query(Sample).filter(Sample.name == 'SampleB').one()
     sampleC = db.get_session().query(Sample).filter(Sample.name == 'SampleC').one()
 
-    query_result = query(loaded_database_connection).has(QueryFeatureMutation('reference:839:C:G'))
+    query_result = query(loaded_database_connection).hasa(QueryFeatureMutation('reference:839:C:G'))
     assert 2 == len(query_result)
     assert {sampleB.id, sampleC.id} == set(query_result.sample_set)
     assert 9 == len(query_result.universe_set)
@@ -125,7 +125,7 @@ def test_query_single_mutation_two_samples_complement(loaded_database_connection
 
 
 def test_query_single_mutation_no_results(loaded_database_connection: DataIndexConnection):
-    query_result = query(loaded_database_connection).has(QueryFeatureMutation('reference:1:1:A'))
+    query_result = query(loaded_database_connection).hasa(QueryFeatureMutation('reference:1:1:A'))
     assert 0 == len(query_result)
     assert query_result.is_empty()
     assert 9 == len(query_result.universe_set)
@@ -135,8 +135,8 @@ def test_query_chained_mutation(loaded_database_connection: DataIndexConnection)
     db = loaded_database_connection.database
     sampleB = db.get_session().query(Sample).filter(Sample.name == 'SampleB').one()
 
-    query_result = query(loaded_database_connection).has(
-        QueryFeatureMutation('reference:839:C:G')).has(
+    query_result = query(loaded_database_connection).hasa(
+        QueryFeatureMutation('reference:839:C:G')).hasa(
         QueryFeatureMutation('reference:5061:G:A'))
     assert 1 == len(query_result)
     assert {sampleB.id} == set(query_result.sample_set)
@@ -147,8 +147,8 @@ def test_query_chained_mutation_has_mutation(loaded_database_connection: DataInd
     db = loaded_database_connection.database
     sampleB = db.get_session().query(Sample).filter(Sample.name == 'SampleB').one()
 
-    query_result = query(loaded_database_connection).has(
-        'reference:839:C:G', kind='mutation').has(
+    query_result = query(loaded_database_connection).hasa(
+        'reference:839:C:G', kind='mutation').hasa(
         'reference:5061:G:A', kind='mutation')
     assert 1 == len(query_result)
     assert {sampleB.id} == set(query_result.sample_set)
@@ -160,7 +160,7 @@ def test_query_mlst_allele(loaded_database_connection: DataIndexConnection):
     sample1 = db.get_session().query(Sample).filter(Sample.name == 'CFSAN002349').one()
     sample2 = db.get_session().query(Sample).filter(Sample.name == 'CFSAN023463').one()
 
-    query_result = query(loaded_database_connection).has(QueryFeatureMLST('lmonocytogenes:abcZ:1'))
+    query_result = query(loaded_database_connection).hasa(QueryFeatureMLST('lmonocytogenes:abcZ:1'))
     assert 2 == len(query_result)
     assert {sample1.id, sample2.id} == set(query_result.sample_set)
     assert 9 == len(query_result.universe_set)
@@ -173,8 +173,8 @@ def test_query_chained_mlst_alleles(loaded_database_connection: DataIndexConnect
     db = loaded_database_connection.database
     sample1 = db.get_session().query(Sample).filter(Sample.name == 'CFSAN002349').one()
 
-    query_result = query(loaded_database_connection).has(
-        QueryFeatureMLST('lmonocytogenes:abcZ:1')).has(
+    query_result = query(loaded_database_connection).hasa(
+        QueryFeatureMLST('lmonocytogenes:abcZ:1')).hasa(
         QueryFeatureMLST('lmonocytogenes:lhkA:4'))
     assert 1 == len(query_result)
     assert {sample1.id} == set(query_result.sample_set)
@@ -186,8 +186,8 @@ def test_query_chained_mlst_alleles_has_allele(loaded_database_connection: DataI
     sample1 = db.get_session().query(Sample).filter(Sample.name == 'CFSAN002349').one()
 
     query_result = query(loaded_database_connection) \
-        .has('lmonocytogenes:abcZ:1', kind='mlst') \
-        .has('lmonocytogenes:lhkA:4', kind='mlst')
+        .hasa('lmonocytogenes:abcZ:1', kind='mlst') \
+        .hasa('lmonocytogenes:lhkA:4', kind='mlst')
     assert 1 == len(query_result)
     assert {sample1.id} == set(query_result.sample_set)
     assert 9 == len(query_result.universe_set)
@@ -199,8 +199,8 @@ def test_query_chained_mlst_nucleotide(loaded_database_connection: DataIndexConn
     sample1 = db.get_session().query(Sample).filter(Sample.name == 'SampleC').one()
 
     query_result = query(loaded_database_connection) \
-        .has('reference:839:C:G', kind='mutation') \
-        .has('lmonocytogenes:cat:12', kind='mlst')
+        .hasa('reference:839:C:G', kind='mutation') \
+        .hasa('lmonocytogenes:cat:12', kind='mlst')
     assert 1 == len(query_result)
     assert {sample1.id} == set(query_result.sample_set)
     assert 9 == len(query_result.universe_set)
@@ -214,7 +214,7 @@ def test_query_single_mutation_dataframe(loaded_database_connection: DataIndexCo
     sampleB = db.get_session().query(Sample).filter(Sample.name == 'SampleB').one()
     sampleC = db.get_session().query(Sample).filter(Sample.name == 'SampleC').one()
 
-    df = query(loaded_database_connection).has('reference:839:C:G', kind='mutation').toframe()
+    df = query(loaded_database_connection).hasa('reference:839:C:G', kind='mutation').toframe()
 
     assert 2 == len(df)
     assert ['Query', 'Sample Name', 'Sample ID', 'Status'] == df.columns.tolist()
@@ -226,7 +226,7 @@ def test_query_single_mutation_dataframe(loaded_database_connection: DataIndexCo
 
 
 def test_query_single_mutation_dataframe_include_all(loaded_database_connection: DataIndexConnection):
-    df = query(loaded_database_connection).has(
+    df = query(loaded_database_connection).hasa(
         'reference:839:C:G', kind='mutation').toframe(exclude_absent=False)
 
     assert 9 == len(df)
@@ -247,8 +247,8 @@ def test_query_chained_allele_dataframe(loaded_database_connection: DataIndexCon
     sample1 = db.get_session().query(Sample).filter(Sample.name == 'CFSAN002349').one()
 
     df = query(loaded_database_connection) \
-        .has('lmonocytogenes:abcZ:1', kind='mlst') \
-        .has('lmonocytogenes:lhkA:4', kind='mlst').toframe()
+        .hasa('lmonocytogenes:abcZ:1', kind='mlst') \
+        .hasa('lmonocytogenes:lhkA:4', kind='mlst').toframe()
 
     assert 1 == len(df)
     assert ['Query', 'Sample Name', 'Sample ID', 'Status'] == df.columns.tolist()
@@ -260,13 +260,13 @@ def test_query_chained_allele_dataframe(loaded_database_connection: DataIndexCon
 
 
 def test_query_single_mutation_no_results_toframe(loaded_database_connection: DataIndexConnection):
-    df = query(loaded_database_connection).has('reference:1:1:A', kind='mutation').toframe()
+    df = query(loaded_database_connection).hasa('reference:1:1:A', kind='mutation').toframe()
     assert 0 == len(df)
     assert ['Query', 'Sample Name', 'Sample ID', 'Status'] == df.columns.tolist()
 
 
 def test_query_single_mutation_no_results_summary(loaded_database_connection: DataIndexConnection):
-    df = query(loaded_database_connection).has('reference:1:1:A', kind='mutation').summary()
+    df = query(loaded_database_connection).hasa('reference:1:1:A', kind='mutation').summary()
     assert 1 == len(df)
     assert ['Query', 'Present', 'Absent', 'Unknown', 'Total',
             '% Present', '% Absent', '% Unknown'] == df.columns.tolist()
@@ -335,7 +335,7 @@ def test_join_custom_dataframe_single_query(loaded_database_connection: DataInde
     assert 3 == len(query_result)
     assert 3 == len(query_result.universe_set)
 
-    query_result = query_result.has('reference:839:C:G', kind='mutation')
+    query_result = query_result.hasa('reference:839:C:G', kind='mutation')
     assert 2 == len(query_result)
     assert 3 == len(query_result.universe_set)
     assert {sampleB.id, sampleC.id} == set(query_result.sample_set)
@@ -370,7 +370,7 @@ def test_join_custom_dataframe_single_query_sample_names(loaded_database_connect
     assert 3 == len(query_result)
     assert 3 == len(query_result.universe_set)
 
-    query_result = query_result.has('reference:839:C:G', kind='mutation')
+    query_result = query_result.hasa('reference:839:C:G', kind='mutation')
 
     assert 2 == len(query_result)
     assert 3 == len(query_result.universe_set)
@@ -407,7 +407,7 @@ def test_join_custom_dataframe_extra_sample_names(loaded_database_connection: Da
     assert 3 == len(query_result)
     assert 3 == len(query_result.universe_set)
 
-    query_result = query_result.has('reference:839:C:G', kind='mutation')
+    query_result = query_result.hasa('reference:839:C:G', kind='mutation')
     df = query_result.toframe()
 
     assert 2 == len(df)
@@ -438,7 +438,7 @@ def test_join_custom_dataframe_missing_sample_names(loaded_database_connection: 
     assert 2 == len(df)
     assert 2 == len(query_result.universe_set)
 
-    df = query_result.has('reference:839:C:G', kind='mutation').toframe()
+    df = query_result.hasa('reference:839:C:G', kind='mutation').toframe()
 
     assert 1 == len(df)
     assert 2 == len(query_result.universe_set)
@@ -468,7 +468,7 @@ def test_query_then_join_dataframe_single_query(loaded_database_connection: Data
     assert 9 == len(query_result)
     assert 9 == len(query_result.universe_set)
 
-    query_result = query_result.has('reference:839:C:G', kind='mutation')
+    query_result = query_result.hasa('reference:839:C:G', kind='mutation')
     assert 2 == len(query_result)
     assert 9 == len(query_result.universe_set)
     assert {sampleB.id, sampleC.id} == set(query_result.sample_set)
@@ -513,7 +513,7 @@ def test_query_join_dataframe_has_dataframe_column(loaded_database_connection: D
     assert 3 == len(query_result)
     assert 3 == len(query_result.universe_set)
 
-    query_result = query_result.has(property=(metadata_df['Color'] == 'red'), kind='dataframe')
+    query_result = query_result.hasa(property=(metadata_df['Color'] == 'red'), kind='dataframe')
 
     assert 1 == len(query_result)
     assert 3 == len(query_result.universe_set)
@@ -521,7 +521,7 @@ def test_query_join_dataframe_has_dataframe_column(loaded_database_connection: D
     df = query_result.toframe()
 
     assert ['SampleA'] == df['Sample Name'].tolist()
-    assert {'dataframe(ids_col=[Sample ID]) AND has(subset from series)'} == set(df['Query'].tolist())
+    assert {'dataframe(ids_col=[Sample ID]) AND hasa(subset from series)'} == set(df['Query'].tolist())
 
 
 def test_query_join_dataframe_has_dataframe_column_select_two_samples(loaded_database_connection: DataIndexConnection):
@@ -541,7 +541,7 @@ def test_query_join_dataframe_has_dataframe_column_select_two_samples(loaded_dat
     assert 3 == len(query_result)
     assert 3 == len(query_result.universe_set)
 
-    query_result = query_result.has(property=(metadata_df['Color'] == 'red'), kind='dataframe')
+    query_result = query_result.hasa(property=(metadata_df['Color'] == 'red'), kind='dataframe')
 
     assert 2 == len(query_result)
     assert 3 == len(query_result.universe_set)
@@ -550,7 +550,7 @@ def test_query_join_dataframe_has_dataframe_column_select_two_samples(loaded_dat
 
     df = df.sort_values(['Sample Name'])
     assert ['SampleA', 'SampleB'] == df['Sample Name'].tolist()
-    assert {'dataframe(ids_col=[Sample ID]) AND has(subset from series)'} == set(df['Query'].tolist())
+    assert {'dataframe(ids_col=[Sample ID]) AND hasa(subset from series)'} == set(df['Query'].tolist())
 
 
 def test_query_join_dataframe_has_dataframe_column_invalid_series_index(
@@ -571,12 +571,12 @@ def test_query_join_dataframe_has_dataframe_column_invalid_series_index(
     query_result = query(loaded_database_connection).join(data_frame=metadata_df, sample_ids_column='Sample ID')
 
     with pytest.raises(Exception) as execinfo:
-        query_result.has(property=invalid_series_select, kind='dataframe')
+        query_result.hasa(property=invalid_series_select, kind='dataframe')
     assert 'does not have same index as internal data frame' in str(execinfo.value)
 
 
 def test_query_and_build_mutation_tree(loaded_database_connection: DataIndexConnection):
-    query_result = query(loaded_database_connection).has('reference:839:C:G', kind='mutation')
+    query_result = query(loaded_database_connection).hasa('reference:839:C:G', kind='mutation')
     assert 2 == len(query_result)
     assert 9 == len(query_result.universe_set)
 
@@ -591,7 +591,7 @@ def test_query_and_build_mutation_tree(loaded_database_connection: DataIndexConn
 
 
 def test_query_build_tree_and_query(loaded_database_connection: DataIndexConnection):
-    query_result = query(loaded_database_connection).has('reference:839:C:G', kind='mutation')
+    query_result = query(loaded_database_connection).hasa('reference:839:C:G', kind='mutation')
     assert 2 == len(query_result)
     assert 9 == len(query_result.universe_set)
 
@@ -599,7 +599,7 @@ def test_query_build_tree_and_query(loaded_database_connection: DataIndexConnect
     assert 2 == len(query_result)
     assert 9 == len(query_result.universe_set)
 
-    query_result = query_result.has('reference:5061:G:A', kind='mutation')
+    query_result = query_result.hasa('reference:5061:G:A', kind='mutation')
     assert 1 == len(query_result)
     assert 9 == len(query_result.universe_set)
 
@@ -611,9 +611,9 @@ def test_query_build_tree_dataframe(loaded_database_connection: DataIndexConnect
     db = loaded_database_connection.database
     sampleB = db.get_session().query(Sample).filter(Sample.name == 'SampleB').one()
 
-    df = query(loaded_database_connection).has(
+    df = query(loaded_database_connection).hasa(
         'reference:839:C:G', kind='mutation').build_tree(
-        kind='mutation', scope='genome', include_reference=True).has(
+        kind='mutation', scope='genome', include_reference=True).hasa(
         'reference:5061:G:A', kind='mutation').toframe()
 
     assert 1 == len(df)
@@ -637,7 +637,7 @@ def test_query_then_build_tree_then_join_dataframe(loaded_database_connection: D
         [sampleC.id, 'blue']
     ], columns=['Sample ID', 'Color'])
 
-    query_result = query(loaded_database_connection).has('reference:839:C:G', kind='mutation')
+    query_result = query(loaded_database_connection).hasa('reference:839:C:G', kind='mutation')
     assert 2 == len(query_result)
     assert 9 == len(query_result.universe_set)
 
@@ -679,7 +679,7 @@ def test_query_then_build_tree_then_join_dataframe(loaded_database_connection: D
 
 
 def test_within_constructed_tree(loaded_database_connection: DataIndexConnection):
-    query_result = query(loaded_database_connection).has(
+    query_result = query(loaded_database_connection).hasa(
         'reference:839:C:G', kind='mutation').build_tree(
         kind='mutation', scope='genome', include_reference=True, extra_params='--seed 42 -m GTR')
     assert 2 == len(query_result)
@@ -778,7 +778,7 @@ def test_summary_features_two(loaded_database_connection: DataIndexConnection):
         'Mutation': 'count',
     }).rename(columns={'Mutation': 'Count'}).sort_index()
 
-    mutations_df = query(loaded_database_connection).has(
+    mutations_df = query(loaded_database_connection).hasa(
         'reference:839:C:G', kind='mutation').summary_features()
     mutations_df = mutations_df.sort_index()
 

--- a/genomics_data_index/test/integration/api/test_GenomicsDataIndex_api_import.py
+++ b/genomics_data_index/test/integration/api/test_GenomicsDataIndex_api_import.py
@@ -46,17 +46,17 @@ def test_query_single_mutation(loaded_genomics_index: gdi.GenomicsDataIndex):
     sample1 = db.get_session().query(Sample).filter(Sample.name == 'CFSAN002349').one()
     sample2 = db.get_session().query(Sample).filter(Sample.name == 'CFSAN023463').one()
 
-    query_result = gi.samples_query().has(QueryFeatureMutation('reference:5061:G:A'))
+    query_result = gi.samples_query().hasa(QueryFeatureMutation('reference:5061:G:A'))
     assert 1 == len(query_result)
     assert {sampleB.id} == set(query_result.sample_set)
     assert 9 == len(query_result.universe_set)
 
-    query_result = gi.samples_query().has(QueryFeatureMutation('reference:5061:G:A'))
+    query_result = gi.samples_query().hasa(QueryFeatureMutation('reference:5061:G:A'))
     assert 1 == len(query_result)
     assert {sampleB.id} == set(query_result.sample_set)
     assert 9 == len(query_result.universe_set)
 
-    query_result = gi.samples_query().has(QueryFeatureMLST('lmonocytogenes:abcZ:1'))
+    query_result = gi.samples_query().hasa(QueryFeatureMLST('lmonocytogenes:abcZ:1'))
     assert 2 == len(query_result)
     assert {sample1.id, sample2.id} == set(query_result.sample_set)
     assert 9 == len(query_result.universe_set)

--- a/genomics_data_index/test/integration/storage/service/test_CoreAlignmentService.py
+++ b/genomics_data_index/test/integration/storage/service/test_CoreAlignmentService.py
@@ -70,7 +70,7 @@ def expected_alignment_core() -> MultipleSeqAlignment:
     includes some complex events in the alignment which I do not include.
     I modify this expected alignment (from snippy) by subtracting 2 SNVs/SNPs introduced
     by complex events. That way I can compare the alignments for equality.
-    :return: The exepcted alignment as a MultipleSeqAlignment object.
+    :return: The expected alignment as a MultipleSeqAlignment object.
     '''
     with open(data_dir / 'snippy.core.aln', 'r') as f:
         alignments = list(AlignIO.parse(f, 'fasta'))


### PR DESCRIPTION
Changed around my query language terms. Specifically:

* Made more general `isin()` which can query for samples in a list of names, or used for querying for distance.
   * Sample names: `isin(["SampleA", "SampleB"])`
   * Distance: `isin("SampleA", kind="distance", distance=1, units="substitutions")`
   *  Dataframe: `isin(df["Column"] == "value", kind="dataframe")`
* Made convenience method `within()` which is equivalent to `isin(kind="distance")`
* Made `isa()` which can either select by sample name, or by a value in a column in a dataframe
   * For example `isa("value", isa_column="Column")`
   * You can set default `isa_column="Column"` when joining to a dataframe and so run in a simpler form like `isa("value")`
   * This also accepts regexes, so you can do `isa(r"^val", regex=True)`
* Changed `has()` to `hasa()` to match `isa()` (I can't just use `is()` since this is a Python keyword).