### PR TITLE
Fix/empty universe

### DIFF
--- a/genomics_data_index/api/query/impl/SamplesQueryIndex.py
+++ b/genomics_data_index/api/query/impl/SamplesQueryIndex.py
@@ -332,10 +332,15 @@ class SamplesQueryIndex(SamplesQuery):
         universe_length = len(self.universe_set)
         unknown_length = len(self.unknown_set)
         selected_length = len(self)
-        percent_selected = (selected_length / universe_length) * 100
-        percent_unknown = (unknown_length / universe_length) * 100
-        return f'<{self.__class__.__name__}[selected={percent_selected:0.0f}% ' \
-               f'({selected_length}/{universe_length}) samples, unknown={percent_unknown:0.0f}% ' \
+        if universe_length > 0:
+            percent_selected = f'{(selected_length / universe_length) * 100:0.0f}'
+            percent_unknown = f'{(unknown_length / universe_length) * 100:0.0f}'
+        else:
+            percent_selected = 'NA'
+            percent_unknown = 'NA'
+
+        return f'<{self.__class__.__name__}[selected={percent_selected}% ' \
+               f'({selected_length}/{universe_length}) samples, unknown={percent_unknown}% ' \
                f'({unknown_length}/{universe_length}) samples]>'
 
     def tolist(self, names: bool = True, include_present: bool = True,

--- a/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
@@ -203,10 +203,16 @@ class WrappedSamplesQuery(SamplesQuery, abc.ABC):
         universe_length = len(self.universe_set)
         unknown_length = len(self.unknown_set)
         selected_length = len(self)
-        percent_selected = (selected_length / universe_length) * 100
-        percent_unknown = (unknown_length / universe_length) * 100
-        return f'<{self.__class__.__name__}[selected={percent_selected:0.0f}% ' \
-               f'({selected_length}/{universe_length}) samples, unknown={percent_unknown:0.0f}% ' \
+
+        if universe_length > 0:
+            percent_selected = f'{(selected_length / universe_length) * 100:0.0f}'
+            percent_unknown = f'{(unknown_length / universe_length) * 100:0.0f}'
+        else:
+            percent_selected = 'NA'
+            percent_unknown = 'NA'
+
+        return f'<{self.__class__.__name__}[selected={percent_selected}% ' \
+               f'({selected_length}/{universe_length}) samples, unknown={percent_unknown}% ' \
                f'({unknown_length}/{universe_length}) samples]>'
 
     def __repr__(self) -> str:

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
@@ -50,6 +50,24 @@ def test_initialized_query_mutations(loaded_database_connection_with_built_tree:
     assert initial_query.tree is not None
 
 
+def test_empty_universe(loaded_database_connection: DataIndexConnection):
+    query_result = query(loaded_database_connection).isin('empty')
+    assert 0 == len(query_result)
+    assert 0 == len(query_result.unknown_set)
+    assert 9 == len(query_result.absent_set)
+    assert 9 == len(query_result.universe_set)
+
+    query_result = query_result.reset_universe()
+    assert 0 == len(query_result)
+    assert 0 == len(query_result.unknown_set)
+    assert 0 == len(query_result.absent_set)
+    assert 0 == len(query_result.universe_set)
+
+    assert '<SamplesQueryIndex[' in str(query_result)
+    assert 'selected=NA%' in str(query_result)
+    assert 'unknown=NA%' in str(query_result)
+
+
 def test_query_isin_samples(loaded_database_connection: DataIndexConnection):
     db = loaded_database_connection.database
     sampleB = db.get_session().query(Sample).filter(Sample.name == 'SampleB').one()

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
@@ -2635,6 +2635,30 @@ def test_query_then_build_tree_then_join_dataframe(loaded_database_connection: D
     assert 2 == len(query_result.universe_set)
 
 
+def test_empty_universe_tree_query(prebuilt_tree: Tree, loaded_database_connection: DataIndexConnection):
+    query_result = query(loaded_database_connection).join_tree(
+        tree=prebuilt_tree, kind='mutation',
+        reference_name='genome',
+        alignment_length=5180)
+
+    query_result = query_result.isa('invalid_name')
+
+    assert 0 == len(query_result)
+    assert 0 == len(query_result.unknown_set)
+    assert 9 == len(query_result.absent_set)
+    assert 9 == len(query_result.universe_set)
+
+    query_result = query_result.reset_universe()
+    assert 0 == len(query_result)
+    assert 0 == len(query_result.unknown_set)
+    assert 0 == len(query_result.absent_set)
+    assert 0 == len(query_result.universe_set)
+
+    assert '<MutationTreeSamplesQuery[' in str(query_result)
+    assert 'selected=NA%' in str(query_result)
+    assert 'unknown=NA%' in str(query_result)
+
+
 def test_query_tree_join_dataframe_isa_dataframe_column(loaded_database_connection: DataIndexConnection):
     db = loaded_database_connection.database
     sampleA = db.get_session().query(Sample).filter(Sample.name == 'SampleA').one()


### PR DESCRIPTION
Fixes division by zero error when converting SamplesQuery with an empty universe to a string.