### PR TITLE
Fixing up bcftools commands to not miss variants

### DIFF
--- a/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
+++ b/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
@@ -103,7 +103,7 @@ rule assembly_variant:
     shell:
         "bcftools mpileup -a DP --min-ireads 1 --threads {threads} -Ou -f {input.reference} {input.bam} 2> {log.mpileup} | "
         "bcftools call --threads {threads} --ploidy 1 -Ou -mv 2> {log.call} | "
-        "bcftools norm --threads {threads} --old-rec-tag -m+both -f {input.reference} -Oz 1> {output} 2> {log.norm}"
+        "bcftools norm --threads {threads} --old-rec-tag -f {input.reference} -Oz 1> {output} 2> {log.norm}"
 
 
 rule reads_paired_snippy:

--- a/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
+++ b/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
@@ -99,9 +99,11 @@ rule assembly_variant:
     log:
         mpileup="logs/assembly_variant.{sample}.mpileup.log",
         call="logs/assembly_variant.{sample}.call.log",
+        norm="logs/assembly_variant.{sample}.norm.log",
     shell:
         "bcftools mpileup -a DP --min-ireads 1 --threads {threads} -Ou -f {input.reference} {input.bam} 2> {log.mpileup} | "
-        "bcftools call --threads {threads} --ploidy 1 -Oz -mv 1> {output}"
+        "bcftools call --threads {threads} --ploidy 1 -Ou -mv 2> {log.call} | "
+        "bcftools norm --threads {threads} --old-rec-tag -m+both -f {input.reference} -Oz 1> {output} 2> {log.norm}"
 
 
 rule reads_paired_snippy:

--- a/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
+++ b/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
@@ -100,7 +100,7 @@ rule assembly_variant:
         mpileup="logs/assembly_variant.{sample}.mpileup.log",
         call="logs/assembly_variant.{sample}.call.log",
     shell:
-        "bcftools mpileup --threads {threads} -Ou -f {input.reference} {input.bam} 2> {log.mpileup} | "
+        "bcftools mpileup -a DP --min-ireads 1 --threads {threads} -Ou -f {input.reference} {input.bam} 2> {log.mpileup} | "
         "bcftools call --threads {threads} --ploidy 1 -Oz -mv 1> {output}"
 
 

--- a/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
+++ b/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
@@ -103,7 +103,7 @@ rule assembly_variant:
     shell:
         "bcftools mpileup -a DP --min-ireads 1 --threads {threads} -Ou -f {input.reference} {input.bam} 2> {log.mpileup} | "
         "bcftools call --threads {threads} --ploidy 1 -Ou -mv 2> {log.call} | "
-        "bcftools norm -f {input.reference} --threads {threads} --old-rec-tag -Oz 1> {output} 2> {log.norm}"
+        "bcftools norm -f {input.reference} --threads {threads} --old-rec-tag -Oz -o {output} 2> {log.norm}"
 
 
 rule reads_paired_snippy:

--- a/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
+++ b/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
@@ -103,7 +103,7 @@ rule assembly_variant:
     shell:
         "bcftools mpileup -a DP --min-ireads 1 --threads {threads} -Ou -f {input.reference} {input.bam} 2> {log.mpileup} | "
         "bcftools call --threads {threads} --ploidy 1 -Ou -mv 2> {log.call} | "
-        "bcftools norm --threads {threads} --old-rec-tag -f {input.reference} -Oz 1> {output} 2> {log.norm}"
+        "bcftools norm -f {input.reference} --threads {threads} --old-rec-tag -Oz 1> {output} 2> {log.norm}"
 
 
 rule reads_paired_snippy:


### PR DESCRIPTION
# 1. Fixed missing indels

Adding `--min-ireads 1` to the `bcftools mpileup` command for calling indels on assmblies:

```
  -m, --min-ireads INT    minimum number gapped reads for indel candidates [2]
```

The default is **2**, which means you'd need 2 reads to call indels. However, for assemblies (where we treat an assembly as a read as output by minimap2) we would only have 1 "read". Hence, this value needs to be set to 1.

# 2. Fixed normalization

Added the command:

```
bcftools norm --old-rec-tag -f reference.fasta
```

to normalize variants so they can be better compared.