### PR TITLE
Feature/query batcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.3.0
 
-* [api]: Added ability to generate a DataFrame of percents of features present in selected samples. To be used for comparing different categories of samples.
+* [api]: Added ability to generate a DataFrame of percents of features present in selected samples. To be used for comparing different categories of samples (0.3.0.dev1).
+* [api]: Added ability to handle joining larger dataframes to sets of samples by batching SQL queries (0.3.0.dev2).
 
 # 0.2.0
 

--- a/genomics_data_index/__init__.py
+++ b/genomics_data_index/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = '0.3.0.dev1'
+__version__: str = '0.3.0.dev2'

--- a/genomics_data_index/configuration/connector/DataIndexConnection.py
+++ b/genomics_data_index/configuration/connector/DataIndexConnection.py
@@ -118,7 +118,7 @@ class DataIndexConnection:
         sql_select_limit = 500
 
         reference_service = ReferenceService(database, filesystem_storage.reference_dir)
-        sample_service = SampleService(database)
+        sample_service = SampleService(database, sql_select_limit=sql_select_limit)
         variation_service = VariationService(database_connection=database,
                                              variation_dir=filesystem_storage.variation_dir,
                                              reference_service=reference_service,

--- a/genomics_data_index/configuration/connector/DataIndexConnection.py
+++ b/genomics_data_index/configuration/connector/DataIndexConnection.py
@@ -115,7 +115,10 @@ class DataIndexConnection:
         database = DatabaseConnection(connection_string=database_connection,
                                       database_path_translator=dpt)
 
-        sql_select_limit = 500
+        # According to <https://www.sqlite.org/limits.html> (**Maximum Number Of Host Parameters In A Single
+        #  SQL Statement**), the maximum number of parameters is 32766 (for SQLite, but depends on version).
+        # TODO: Make this configurable
+        sql_select_limit = 32766
 
         reference_service = ReferenceService(database, filesystem_storage.reference_dir)
         sample_service = SampleService(database, sql_select_limit=sql_select_limit)

--- a/genomics_data_index/storage/service/SampleService.py
+++ b/genomics_data_index/storage/service/SampleService.py
@@ -15,7 +15,7 @@ from genomics_data_index.storage.model.db import NucleotideVariantsSamples, Refe
     SampleMLSTAlleles, MLSTAllelesSamples, Sample
 from genomics_data_index.storage.model.db import SampleNucleotideVariation
 from genomics_data_index.storage.service import DatabaseConnection
-from genomics_data_index.storage.service import SQLQueryInBatcher
+from genomics_data_index.storage.service import SQLQueryInBatcherDict, SQLQueryInBatcherList
 
 logger = logging.getLogger(__name__)
 
@@ -421,7 +421,7 @@ class SampleService:
         :param sample_names: The sample names to search.
         :return: A dictionary linking the sample names to IDs.
         """
-        query_batcher = SQLQueryInBatcher(in_data=list(sample_names), batch_size=self._sql_select_limit)
+        query_batcher = SQLQueryInBatcherDict(in_data=list(sample_names), batch_size=self._sql_select_limit)
 
         def handle_batch(sample_names_batch: List[str]) -> Dict[str, int]:
             sample_tuples = self._connection.get_session().query(Sample.name, Sample.id) \

--- a/genomics_data_index/storage/service/VariationService.py
+++ b/genomics_data_index/storage/service/VariationService.py
@@ -22,7 +22,6 @@ from genomics_data_index.storage.service import DatabaseConnection
 from genomics_data_index.storage.service.FeatureService import FeatureService
 from genomics_data_index.storage.service.ReferenceService import ReferenceService
 from genomics_data_index.storage.service.SampleService import SampleService
-from genomics_data_index.storage.util import TRACE_LEVEL
 from genomics_data_index.storage.service import SQLQueryInBatcher
 from genomics_data_index.storage.util.SamplesProgressLogger import SamplesProgressLogger
 

--- a/genomics_data_index/storage/service/VariationService.py
+++ b/genomics_data_index/storage/service/VariationService.py
@@ -19,7 +19,7 @@ from genomics_data_index.storage.model.QueryFeatureMutationSPDI import QueryFeat
 from genomics_data_index.storage.model.db import NucleotideVariantsSamples, SampleNucleotideVariation, Sample, \
     FeatureSamples
 from genomics_data_index.storage.service import DatabaseConnection
-from genomics_data_index.storage.service import SQLQueryInBatcher
+from genomics_data_index.storage.service import SQLQueryInBatcherDict
 from genomics_data_index.storage.service.FeatureService import FeatureService
 from genomics_data_index.storage.service.ReferenceService import ReferenceService
 from genomics_data_index.storage.service.SampleService import SampleService
@@ -320,7 +320,7 @@ class VariationService(FeatureService):
         if isinstance(feature_ids, set):
             feature_ids = list(feature_ids)
 
-        query_batcher = SQLQueryInBatcher(in_data=feature_ids, batch_size=self._sql_select_limit)
+        query_batcher = SQLQueryInBatcherDict(in_data=feature_ids, batch_size=self._sql_select_limit)
 
         def handle_batch(feature_ids_batch: List[str]) -> Dict[str, FeatureSamples]:
             feature_samples = self._connection.get_session().query(NucleotideVariantsSamples) \

--- a/genomics_data_index/storage/service/VariationService.py
+++ b/genomics_data_index/storage/service/VariationService.py
@@ -19,10 +19,10 @@ from genomics_data_index.storage.model.QueryFeatureMutationSPDI import QueryFeat
 from genomics_data_index.storage.model.db import NucleotideVariantsSamples, SampleNucleotideVariation, Sample, \
     FeatureSamples
 from genomics_data_index.storage.service import DatabaseConnection
+from genomics_data_index.storage.service import SQLQueryInBatcher
 from genomics_data_index.storage.service.FeatureService import FeatureService
 from genomics_data_index.storage.service.ReferenceService import ReferenceService
 from genomics_data_index.storage.service.SampleService import SampleService
-from genomics_data_index.storage.service import SQLQueryInBatcher
 from genomics_data_index.storage.util.SamplesProgressLogger import SamplesProgressLogger
 
 logger = logging.getLogger(__name__)

--- a/genomics_data_index/storage/service/__init__.py
+++ b/genomics_data_index/storage/service/__init__.py
@@ -1,7 +1,7 @@
 import abc
 import logging
 from pathlib import Path
-from typing import List, Callable, Dict, Any, Union
+from typing import List, Callable, Any, Union
 
 import pandas as pd
 from sqlalchemy import create_engine

--- a/genomics_data_index/storage/service/__init__.py
+++ b/genomics_data_index/storage/service/__init__.py
@@ -9,8 +9,8 @@ from sqlalchemy.orm import sessionmaker
 import genomics_data_index.storage.model.db
 from genomics_data_index.storage.model.db import Base
 from genomics_data_index.storage.model.db.DatabasePathTranslator import DatabasePathTranslator
-from genomics_data_index.storage.util.ListSliceIter import ListSliceIter
 from genomics_data_index.storage.util import TRACE_LEVEL
+from genomics_data_index.storage.util.ListSliceIter import ListSliceIter
 
 logger = logging.getLogger(__name__)
 

--- a/genomics_data_index/test/integration/storage/service/conftest.py
+++ b/genomics_data_index/test/integration/storage/service/conftest.py
@@ -141,7 +141,16 @@ def reference_service_with_snpeff_data(reference_service) -> ReferenceService:
 
 @pytest.fixture
 def sample_service(database):
-    return SampleService(database)
+    return SampleService(database, sql_select_limit=500)
+
+
+@pytest.fixture
+def sample_service_select1(database):
+    return SampleService(database, sql_select_limit=1)
+
+@pytest.fixture
+def sample_service_select2(database):
+    return SampleService(database, sql_select_limit=2)
 
 
 @pytest.fixture

--- a/genomics_data_index/test/integration/storage/service/conftest.py
+++ b/genomics_data_index/test/integration/storage/service/conftest.py
@@ -148,6 +148,7 @@ def sample_service(database):
 def sample_service_select1(database):
     return SampleService(database, sql_select_limit=1)
 
+
 @pytest.fixture
 def sample_service_select2(database):
     return SampleService(database, sql_select_limit=2)

--- a/genomics_data_index/test/integration/storage/service/test_DatabaseConnection.py
+++ b/genomics_data_index/test/integration/storage/service/test_DatabaseConnection.py
@@ -21,7 +21,7 @@ def setup_services(root_dir: Path, database_file: Path) -> Dict[str, Any]:
     dpt = DatabasePathTranslator(filesystem_storage.root_dir)
     db_connection = DatabaseConnection(f'sqlite:///{database_file}', dpt)
     reference_service = ReferenceService(db_connection, filesystem_storage.reference_dir)
-    sample_service = SampleService(db_connection)
+    sample_service = SampleService(db_connection, sql_select_limit=500)
     variation_service = VariationService(database_connection=db_connection,
                                          reference_service=reference_service,
                                          sample_service=sample_service,

--- a/genomics_data_index/test/integration/storage/service/test_SampleService.py
+++ b/genomics_data_index/test/integration/storage/service/test_SampleService.py
@@ -175,6 +175,24 @@ def test_find_samples_by_ids_3_samples(sample_service, variation_service):
     assert {'SampleA', 'SampleB', 'SampleC'} == {s.name for s in samples}
 
 
+def test_find_samples_by_ids_3_samples_select1(sample_service_select1, variation_service):
+    sample_name_ids = sample_service_select1.find_sample_name_ids(['SampleA', 'SampleB', 'SampleC'])
+    sample_set = SampleSet(sample_ids=[sample_name_ids['SampleA'], sample_name_ids['SampleB'],
+                                       sample_name_ids['SampleC']])
+
+    samples = sample_service_select1.find_samples_by_ids(sample_set)
+    assert {'SampleA', 'SampleB', 'SampleC'} == {s.name for s in samples}
+
+
+def test_find_samples_by_ids_3_samples_select2(sample_service_select2, variation_service):
+    sample_name_ids = sample_service_select2.find_sample_name_ids(['SampleA', 'SampleB', 'SampleC'])
+    sample_set = SampleSet(sample_ids=[sample_name_ids['SampleA'], sample_name_ids['SampleB'],
+                                       sample_name_ids['SampleC']])
+
+    samples = sample_service_select2.find_samples_by_ids(sample_set)
+    assert {'SampleA', 'SampleB', 'SampleC'} == {s.name for s in samples}
+
+
 def test_find_samples_by_features_variations(database, sample_service, variation_service):
     sampleB = database.get_session().query(Sample).filter(Sample.name == 'SampleB').one()
 

--- a/genomics_data_index/test/integration/storage/service/test_SampleService.py
+++ b/genomics_data_index/test/integration/storage/service/test_SampleService.py
@@ -46,9 +46,29 @@ def test_find_sample_name_ids(database, sample_service, variation_service):
     sampleB = database.get_session().query(Sample).filter(Sample.name == 'SampleB').one()
     sampleC = database.get_session().query(Sample).filter(Sample.name == 'SampleC').one()
 
-    sample_ids_list = sample_service.find_sample_name_ids(['SampleA', 'SampleB', 'SampleC'])
+    sample_ids_dict = sample_service.find_sample_name_ids(['SampleA', 'SampleB', 'SampleC'])
 
-    assert {sampleA.name: sampleA.id, sampleB.name: sampleB.id, sampleC.name: sampleC.id} == sample_ids_list
+    assert {sampleA.name: sampleA.id, sampleB.name: sampleB.id, sampleC.name: sampleC.id} == sample_ids_dict
+
+
+def test_find_sample_name_ids_select1(database, sample_service_select1, variation_service):
+    sampleA = database.get_session().query(Sample).filter(Sample.name == 'SampleA').one()
+    sampleB = database.get_session().query(Sample).filter(Sample.name == 'SampleB').one()
+    sampleC = database.get_session().query(Sample).filter(Sample.name == 'SampleC').one()
+
+    sample_ids_dict = sample_service_select1.find_sample_name_ids(['SampleA', 'SampleB', 'SampleC'])
+
+    assert {sampleA.name: sampleA.id, sampleB.name: sampleB.id, sampleC.name: sampleC.id} == sample_ids_dict
+
+
+def test_find_sample_name_ids_select2(database, sample_service_select2, variation_service):
+    sampleA = database.get_session().query(Sample).filter(Sample.name == 'SampleA').one()
+    sampleB = database.get_session().query(Sample).filter(Sample.name == 'SampleB').one()
+    sampleC = database.get_session().query(Sample).filter(Sample.name == 'SampleC').one()
+
+    sample_ids_dict = sample_service_select2.find_sample_name_ids(['SampleA', 'SampleB', 'SampleC'])
+
+    assert {sampleA.name: sampleA.id, sampleB.name: sampleB.id, sampleC.name: sampleC.id} == sample_ids_dict
 
 
 def test_count_samples_associated_with_reference(sample_service, variation_service):

--- a/genomics_data_index/test/unit/variant/service/test_SQLQueryInBatcher.py
+++ b/genomics_data_index/test/unit/variant/service/test_SQLQueryInBatcher.py
@@ -1,33 +1,65 @@
-from genomics_data_index.storage.service import SQLQueryInBatcher
+from genomics_data_index.storage.service import SQLQueryInBatcherDict, SQLQueryInBatcherList
 
 
-def test_sql_query_in_batcher():
+def test_sql_query_in_batcher_dict():
     in_data = ['A', 'B', 'C', 'D', 'E']
 
     # Test batch size 1
-    batcher = SQLQueryInBatcher(in_data=in_data, batch_size=1)
+    batcher = SQLQueryInBatcherDict(in_data=in_data, batch_size=1)
     results = batcher.process(lambda in_batch: {x: True for x in in_batch})
     assert isinstance(results, dict)
     assert 5 == len(results)
     assert {'A', 'B', 'C', 'D', 'E'} == set(results.keys())
 
     # Test batch size 2
-    batcher = SQLQueryInBatcher(in_data=in_data, batch_size=2)
+    batcher = SQLQueryInBatcherDict(in_data=in_data, batch_size=2)
     results = batcher.process(lambda in_batch: {x: True for x in in_batch})
     assert isinstance(results, dict)
     assert 5 == len(results)
     assert {'A', 'B', 'C', 'D', 'E'} == set(results.keys())
 
     # Test batch size 5
-    batcher = SQLQueryInBatcher(in_data=in_data, batch_size=5)
+    batcher = SQLQueryInBatcherDict(in_data=in_data, batch_size=5)
     results = batcher.process(lambda in_batch: {x: True for x in in_batch})
     assert isinstance(results, dict)
     assert 5 == len(results)
     assert {'A', 'B', 'C', 'D', 'E'} == set(results.keys())
 
     # Test batch size 6
-    batcher = SQLQueryInBatcher(in_data=in_data, batch_size=6)
+    batcher = SQLQueryInBatcherDict(in_data=in_data, batch_size=6)
     results = batcher.process(lambda in_batch: {x: True for x in in_batch})
     assert isinstance(results, dict)
     assert 5 == len(results)
     assert {'A', 'B', 'C', 'D', 'E'} == set(results.keys())
+
+
+def test_sql_query_in_batcher_list():
+    in_data = ['A', 'B', 'C', 'D', 'E']
+
+    # Test batch size 1
+    batcher = SQLQueryInBatcherList(in_data=in_data, batch_size=1)
+    results = batcher.process(lambda in_batch: [x for x in in_batch])
+    assert isinstance(results, list)
+    assert 5 == len(results)
+    assert in_data == results
+
+    # Test batch size 2
+    batcher = SQLQueryInBatcherList(in_data=in_data, batch_size=2)
+    results = batcher.process(lambda in_batch: in_batch)
+    assert isinstance(results, list)
+    assert 5 == len(results)
+    assert in_data == results
+
+    # Test batch size 5
+    batcher = SQLQueryInBatcherList(in_data=in_data, batch_size=5)
+    results = batcher.process(lambda in_batch: in_batch)
+    assert isinstance(results, list)
+    assert 5 == len(results)
+    assert in_data == results
+
+    # Test batch size 6
+    batcher = SQLQueryInBatcherList(in_data=in_data, batch_size=6)
+    results = batcher.process(lambda in_batch: in_batch)
+    assert isinstance(results, list)
+    assert 5 == len(results)
+    assert in_data == results

--- a/genomics_data_index/test/unit/variant/service/test_SQLQueryInBatcher.py
+++ b/genomics_data_index/test/unit/variant/service/test_SQLQueryInBatcher.py
@@ -1,0 +1,33 @@
+from genomics_data_index.storage.service import SQLQueryInBatcher
+
+
+def test_sql_query_in_batcher():
+    in_data = ['A', 'B', 'C', 'D', 'E']
+
+    # Test batch size 1
+    batcher = SQLQueryInBatcher(in_data=in_data, batch_size=1)
+    results = batcher.process(lambda in_batch: {x: True for x in in_batch})
+    assert isinstance(results, dict)
+    assert 5 == len(results)
+    assert {'A', 'B', 'C', 'D', 'E'} == set(results.keys())
+
+    # Test batch size 2
+    batcher = SQLQueryInBatcher(in_data=in_data, batch_size=2)
+    results = batcher.process(lambda in_batch: {x: True for x in in_batch})
+    assert isinstance(results, dict)
+    assert 5 == len(results)
+    assert {'A', 'B', 'C', 'D', 'E'} == set(results.keys())
+
+    # Test batch size 5
+    batcher = SQLQueryInBatcher(in_data=in_data, batch_size=5)
+    results = batcher.process(lambda in_batch: {x: True for x in in_batch})
+    assert isinstance(results, dict)
+    assert 5 == len(results)
+    assert {'A', 'B', 'C', 'D', 'E'} == set(results.keys())
+
+    # Test batch size 6
+    batcher = SQLQueryInBatcher(in_data=in_data, batch_size=6)
+    results = batcher.process(lambda in_batch: {x: True for x in in_batch})
+    assert isinstance(results, dict)
+    assert 5 == len(results)
+    assert {'A', 'B', 'C', 'D', 'E'} == set(results.keys())

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(name='genomics-data-index',
-      version='0.3.0.dev1',
+      version='0.3.0.dev2',
       description='Indexes genomics data (mutations, kmers, MLST) for fast querying of features.',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
Creates a method to batch up getting sample name/sample id mappings. I was previously doing this all as a single SQL query, but the `IN` part of the query has a limit on the size of the list you can pass. So I implemented a method to batch this up into smaller SQL queries so that larger datasets can still be processed.