### PR TITLE
Added Type to features_summary and features_comparison and more configurable tree generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [api]: Added ability to generate a DataFrame of percents of features present in selected samples. To be used for comparing different categories of samples (0.3.0.dev1).
 * [api]: Added ability to handle joining larger dataframes to sets of samples by batching SQL queries (0.3.0.dev2).
+* [api]: Added mutation "Type" to the output of summaries/comparison table (0.3.0.dev3).
 
 # 0.2.0
 

--- a/genomics_data_index/__init__.py
+++ b/genomics_data_index/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = '0.3.0.dev2'
+__version__: str = '0.3.0.dev3'

--- a/genomics_data_index/api/query/GenomicsDataIndex.py
+++ b/genomics_data_index/api/query/GenomicsDataIndex.py
@@ -237,12 +237,13 @@ class GenomicsDataIndex:
         for mutation in mutations:
             seq, pos, deletion, insertion = NucleotideMutationTranslater.from_spdi(mutation,
                                                                                    convert_deletion=convert_deletion)
-            count = len(mutations[mutation].sample_ids)
-            data.append([mutation, seq, pos, deletion, insertion, count, total_samples])
+            mutation_obj = mutations[mutation]
+            count = len(mutation_obj.sample_ids)
+            data.append([mutation, seq, pos, deletion, insertion, mutation_obj.var_type, count, total_samples])
 
         features_df = pd.DataFrame(data,
                                    columns=['Mutation', 'Sequence', 'Position',
-                                            'Deletion', 'Insertion', 'Count', 'Total']).set_index('Mutation')
+                                            'Deletion', 'Insertion', 'Type', 'Count', 'Total']).set_index('Mutation')
 
         features_df['Percent'] = 100 * (features_df['Count'] / features_df['Total'])
 

--- a/genomics_data_index/api/query/features/MutationFeaturesFromIndexComparator.py
+++ b/genomics_data_index/api/query/features/MutationFeaturesFromIndexComparator.py
@@ -31,7 +31,7 @@ class MutationFeaturesFromIndexComparator(FeaturesFromIndexComparator):
 
     @property
     def feature_id_columns(self) -> List[str]:
-        return ['Sequence', 'Position', 'Deletion', 'Insertion']
+        return ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type']
 
     @property
     def index_name(self) -> str:
@@ -47,7 +47,7 @@ class MutationFeaturesFromIndexComparator(FeaturesFromIndexComparator):
             query_feature_id = QueryFeatureMutationSPDI(
                 feature_id)  # Use this since db deletion is an int (not sequence)
             return [feature_id, feature.sequence, feature.position,
-                    query_feature_id.deletion, feature.insertion] + summary_data
+                    query_feature_id.deletion, feature.insertion, feature.var_type] + summary_data
         else:
             raise Exception(f'feature={feature} is not of type {NucleotideVariantsSamples.__name__}')
 

--- a/genomics_data_index/api/query/impl/TreeBuilderReferenceMutations.py
+++ b/genomics_data_index/api/query/impl/TreeBuilderReferenceMutations.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union, Iterable, Tuple
+from typing import Union, Iterable, Tuple, List
 
 from ete3 import Tree
 
@@ -32,6 +32,7 @@ class TreeBuilderReferenceMutations(TreeBuilder):
     def _build_iqtree(self, samples_set: Union[SampleSet, Iterable[str]],
                       ncores: int = 1,
                       align_type: str = 'full',
+                      include_variants: List[str] = None,
                       include_reference: bool = True,
                       extra_params: str = None) -> Tuple[Tree, int, SampleSet]:
         sample_service = self._database_connection.sample_service
@@ -56,6 +57,7 @@ class TreeBuilderReferenceMutations(TreeBuilder):
         alignment_data = alignment_service.construct_alignment(reference_name=self._reference_name,
                                                                samples=samples_names,
                                                                align_type=align_type,
+                                                               include_variants=include_variants,
                                                                include_reference=include_reference)
         tree_data, out = tree_service.build_tree(alignment_data, tree_build_type='iqtree',
                                                  num_cores=ncores, align_type=align_type,

--- a/genomics_data_index/cli/gdi.py
+++ b/genomics_data_index/cli/gdi.py
@@ -179,7 +179,7 @@ def load_variants_common(data_index_connection: DataIndexConnection, ncores: int
 @click.option('--sample-batch-size', help='Number of samples to process within a single batch.', default=2000,
               type=click.IntRange(min=1))
 @click.option('--build-tree/--no-build-tree', default=False, help='Builds tree of all samples after loading')
-@click.option('--align-type', help=f'The type of alignment to generate', default='core',
+@click.option('--align-type', help=f'The type of alignment to generate', default='full',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
 @click.option('--include-variants', help=f'Which type of variant to include in tree.',
               default=CoreAlignmentService.INCLUDE_VARIANT_DEFAULT,
@@ -231,7 +231,7 @@ def load_snippy(ctx, snippy_dir: str, reference_file: str, reference_name: str,
 @click.option('--sample-batch-size', help='Number of samples to process within a single batch.', default=2000,
               type=click.IntRange(min=1))
 @click.option('--build-tree/--no-build-tree', default=False, help='Builds tree of all samples after loading')
-@click.option('--align-type', help=f'The type of alignment to generate', default='core',
+@click.option('--align-type', help=f'The type of alignment to generate', default='full',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
 @click.option('--include-variants', help=f'Which type of variant to include in tree.',
               default=CoreAlignmentService.INCLUDE_VARIANT_DEFAULT,
@@ -427,7 +427,7 @@ def input_command(absolute: bool, input_genomes_file: str, genomes: List[str]):
               required=False, default=True)
 @click.option('--clean/--no-clean', help='Clean up intermediate files when finished.', default=True)
 @click.option('--build-tree/--no-build-tree', default=False, help='Builds tree of all samples after loading')
-@click.option('--align-type', help=f'The type of alignment to generate', default='core',
+@click.option('--align-type', help=f'The type of alignment to generate', default='full',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
 @click.option('--include-variants', help=f'Which type of variant to include in tree.',
               default=CoreAlignmentService.INCLUDE_VARIANT_DEFAULT,
@@ -613,7 +613,7 @@ def build(ctx):
 @click.pass_context
 @click.option('--output-file', help='Output file', required=True, type=click.Path())
 @click.option('--reference-name', help='Reference genome name', required=True, type=str)
-@click.option('--align-type', help=f'The type of alignment to generate', default='core',
+@click.option('--align-type', help=f'The type of alignment to generate', default='full',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
 @click.option('--include-variants', help=f'Which type of variant to include.',
               default=CoreAlignmentService.INCLUDE_VARIANT_DEFAULT,
@@ -656,7 +656,7 @@ supported_tree_build_types = ['iqtree']
 @click.pass_context
 @click.option('--output-file', help='Output file', required=True, type=click.Path())
 @click.option('--reference-name', help='Reference genome name', type=str, required=True)
-@click.option('--align-type', help=f'The type of alignment to use for generating the tree', default='core',
+@click.option('--align-type', help=f'The type of alignment to use for generating the tree', default='full',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
 @click.option('--tree-build-type', help=f'The type of tree building software', default='iqtree',
               type=click.Choice(supported_tree_build_types))
@@ -713,7 +713,7 @@ def rebuild(ctx):
 @rebuild.command(name='tree')
 @click.pass_context
 @click.argument('reference', type=str, nargs=-1)
-@click.option('--align-type', help=f'The type of alignment to use for generating the tree', default='core',
+@click.option('--align-type', help=f'The type of alignment to use for generating the tree', default='full',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
 @click.option('--include-variants', help=f'Which type of variant to include.',
               default=CoreAlignmentService.INCLUDE_VARIANT_DEFAULT,

--- a/genomics_data_index/cli/gdi.py
+++ b/genomics_data_index/cli/gdi.py
@@ -7,7 +7,7 @@ from functools import partial
 from os import getcwd, mkdir
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import List, cast
+from typing import List, cast, Tuple
 
 import click
 import click_config_file
@@ -187,10 +187,11 @@ def load_variants_common(data_index_connection: DataIndexConnection, ncores: int
               default=None)
 def load_snippy(ctx, snippy_dir: str, reference_file: str, reference_name: str,
                 index_unknown: bool, sample_batch_size: int, build_tree: bool,
-                align_type: str, include_variants: List[str], extra_tree_params: str):
+                align_type: str, include_variants: Tuple[str], extra_tree_params: str):
     ncores = ctx.obj['ncores']
     project = get_project_exit_on_error(ctx)
     data_index_connection = project.create_connection()
+    include_variants = [v for v in include_variants]
 
     if reference_name is None and reference_file is None:
         logger.error(f'Neither --reference-file nor --reference-name are specified. Please define either '
@@ -237,10 +238,11 @@ def load_snippy(ctx, snippy_dir: str, reference_file: str, reference_name: str,
               default=None)
 def load_vcf(ctx, vcf_fofns: str, reference_file: str, reference_name: str,
              index_unknown: bool, sample_batch_size: int, build_tree: bool, align_type: str,
-             include_variants: List[str], extra_tree_params: str):
+             include_variants: Tuple[str], extra_tree_params: str):
     ncores = ctx.obj['ncores']
     project = get_project_exit_on_error(ctx)
     vcf_fofns = Path(vcf_fofns)
+    include_variants = [v for v in include_variants]
 
     if reference_name is None and reference_file is None:
         logger.error(f'Neither --reference-file nor --reference-name are specified. Please define either '
@@ -470,7 +472,7 @@ def input_command(absolute: bool, input_genomes_file: str, genomes: List[str]):
 @click.argument('genomes', type=click.Path(exists=True), nargs=-1)
 def analysis(ctx, reference_file: str, load_data: bool, index_unknown: bool, clean: bool, build_tree: bool,
              align_type: str,
-             include_variants: List[str],
+             include_variants: Tuple[str],
              extra_tree_params: str, use_conda: bool,
              include_mlst: bool, include_kmer: bool, ignore_snpeff: bool,
              reads_mincov: int, reads_minqual: int,
@@ -615,10 +617,11 @@ def build(ctx):
 @click.option('--sample', help='Sample to include in alignment (can list more than one).',
               multiple=True, type=str)
 def alignment(ctx, output_file: Path, reference_name: str, align_type: str,
-              include_variants: List[str], sample: List[str]):
+              include_variants: Tuple[str], sample: List[str]):
     genomics_index = get_genomics_index(ctx)
     references = genomics_index.reference_names()
     alignment_service = genomics_index.connection.alignment_service
+    include_variants = [v for v in include_variants]
 
     if reference_name not in references:
         logger.error(f'Reference genome [{reference_name}] does not exist')
@@ -659,11 +662,12 @@ supported_tree_build_types = ['iqtree']
               multiple=True, type=str)
 @click.option('--extra-params', help='Extra parameters to tree-building software',
               default=None)
-def tree(ctx, output_file: Path, reference_name: str, align_type: str, include_variants: List[str],
+def tree(ctx, output_file: Path, reference_name: str, align_type: str, include_variants: Tuple[str],
          tree_build_type: str, sample: List[str], extra_params: str):
     genomics_index = get_genomics_index(ctx)
     references = genomics_index.reference_names()
     ncores = ctx.obj['ncores']
+    include_variants = [v for v in include_variants]
 
     if reference_name not in references:
         logger.error(f'Reference genome [{reference_name}] does not exist')
@@ -710,11 +714,12 @@ def rebuild(ctx):
               type=click.Choice(CoreAlignmentService.INCLUDE_VARIANT_TYPES), multiple=True)
 @click.option('--extra-params', help='Extra parameters to tree-building software',
               default=None)
-def rebuild_tree(ctx, reference: List[str], align_type: str, include_variants: List[str], extra_params: str):
+def rebuild_tree(ctx, reference: List[str], align_type: str, include_variants: Tuple[str], extra_params: str):
     data_index_connection = get_project_exit_on_error(ctx).create_connection()
     tree_service = data_index_connection.tree_service
     reference_service = data_index_connection.reference_service
     ncores = ctx.obj['ncores']
+    include_variants = [v for v in include_variants]
 
     if len(reference) == 0:
         logger.error('Must define name of reference genome to use. '

--- a/genomics_data_index/cli/gdi.py
+++ b/genomics_data_index/cli/gdi.py
@@ -120,7 +120,9 @@ def load_variants_common(data_index_connection: DataIndexConnection, ncores: int
                          data_package_factory: SampleDataPackageFactory,
                          reference_file: Path, reference_name: str,
                          input: Path, build_tree: bool,
-                         align_type: str, extra_tree_params: str,
+                         align_type: str,
+                         include_variants: List[str],
+                         extra_tree_params: str,
                          sample_batch_size: int):
     reference_service = data_index_connection.reference_service
     variation_service = cast(VariationService, data_index_connection.variation_service)
@@ -159,6 +161,7 @@ def load_variants_common(data_index_connection: DataIndexConnection, ncores: int
         if build_tree:
             tree_service.rebuild_tree(reference_name=reference_name,
                                       align_type=align_type,
+                                      include_variants=include_variants,
                                       num_cores=ncores,
                                       extra_params=extra_tree_params)
             logger.info('Finished building tree of all samples')
@@ -178,11 +181,13 @@ def load_variants_common(data_index_connection: DataIndexConnection, ncores: int
 @click.option('--build-tree/--no-build-tree', default=False, help='Builds tree of all samples after loading')
 @click.option('--align-type', help=f'The type of alignment to generate', default='core',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
+@click.option('--include-variants', help=f'Which type of variant to include in tree.', default=['SNP'],
+              type=click.Choice(CoreAlignmentService.INCLUDE_VARIANT_TYPES), multiple=True)
 @click.option('--extra-tree-params', help='Extra parameters to tree-building software',
               default=None)
 def load_snippy(ctx, snippy_dir: str, reference_file: str, reference_name: str,
                 index_unknown: bool, sample_batch_size: int, build_tree: bool,
-                align_type: str, extra_tree_params: str):
+                align_type: str, include_variants: List[str], extra_tree_params: str):
     ncores = ctx.obj['ncores']
     project = get_project_exit_on_error(ctx)
     data_index_connection = project.create_connection()
@@ -207,6 +212,7 @@ def load_snippy(ctx, snippy_dir: str, reference_file: str, reference_name: str,
                              reference_file=reference_file,
                              reference_name=reference_name,
                              input=Path(snippy_dir), build_tree=build_tree, align_type=align_type,
+                             include_variants=include_variants,
                              extra_tree_params=extra_tree_params,
                              sample_batch_size=sample_batch_size)
 
@@ -225,10 +231,13 @@ def load_snippy(ctx, snippy_dir: str, reference_file: str, reference_name: str,
 @click.option('--build-tree/--no-build-tree', default=False, help='Builds tree of all samples after loading')
 @click.option('--align-type', help=f'The type of alignment to generate', default='core',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
+@click.option('--include-variants', help=f'Which type of variant to include in tree.', default=['SNP'],
+              type=click.Choice(CoreAlignmentService.INCLUDE_VARIANT_TYPES), multiple=True)
 @click.option('--extra-tree-params', help='Extra parameters to tree-building software',
               default=None)
 def load_vcf(ctx, vcf_fofns: str, reference_file: str, reference_name: str,
-             index_unknown: bool, sample_batch_size: int, build_tree: bool, align_type: str, extra_tree_params: str):
+             index_unknown: bool, sample_batch_size: int, build_tree: bool, align_type: str,
+             include_variants: List[str], extra_tree_params: str):
     ncores = ctx.obj['ncores']
     project = get_project_exit_on_error(ctx)
     vcf_fofns = Path(vcf_fofns)
@@ -255,6 +264,7 @@ def load_vcf(ctx, vcf_fofns: str, reference_file: str, reference_name: str,
                              reference_file=reference_file,
                              reference_name=reference_name,
                              input=Path(vcf_fofns), build_tree=build_tree, align_type=align_type,
+                             include_variants=include_variants,
                              extra_tree_params=extra_tree_params,
                              sample_batch_size=sample_batch_size)
 
@@ -415,6 +425,8 @@ def input_command(absolute: bool, input_genomes_file: str, genomes: List[str]):
 @click.option('--build-tree/--no-build-tree', default=False, help='Builds tree of all samples after loading')
 @click.option('--align-type', help=f'The type of alignment to generate', default='core',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
+@click.option('--include-variants', help=f'Which type of variant to include in tree.', default=['SNP'],
+              type=click.Choice(CoreAlignmentService.INCLUDE_VARIANT_TYPES), multiple=True)
 @click.option('--extra-tree-params', help='Extra parameters to tree-building software',
               default=None)
 @click.option('--use-conda/--no-use-conda', help="Use (or don't use) conda for dependency management for pipeline.",
@@ -458,6 +470,7 @@ def input_command(absolute: bool, input_genomes_file: str, genomes: List[str]):
 @click.argument('genomes', type=click.Path(exists=True), nargs=-1)
 def analysis(ctx, reference_file: str, load_data: bool, index_unknown: bool, clean: bool, build_tree: bool,
              align_type: str,
+             include_variants: List[str],
              extra_tree_params: str, use_conda: bool,
              include_mlst: bool, include_kmer: bool, ignore_snpeff: bool,
              reads_mincov: int, reads_minqual: int,
@@ -526,6 +539,7 @@ def analysis(ctx, reference_file: str, load_data: bool, index_unknown: bool, cle
             logger.info(f'Indexing processed VCF files defined in [{processed_files_fofn}]')
             ctx.invoke(load_vcf, index_unknown=index_unknown, vcf_fofns=str(processed_files_fofn),
                        reference_file=reference_file, build_tree=build_tree, align_type=align_type,
+                       include_variants=include_variants,
                        extra_tree_params=extra_tree_params, sample_batch_size=sample_batch_size)
         except Exception as e:
             logger.exception(e)
@@ -596,9 +610,12 @@ def build(ctx):
 @click.option('--reference-name', help='Reference genome name', required=True, type=str)
 @click.option('--align-type', help=f'The type of alignment to generate', default='core',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
+@click.option('--include-variants', help=f'Which type of variant to include.', default=['SNP'],
+              type=click.Choice(CoreAlignmentService.INCLUDE_VARIANT_TYPES), multiple=True)
 @click.option('--sample', help='Sample to include in alignment (can list more than one).',
               multiple=True, type=str)
-def alignment(ctx, output_file: Path, reference_name: str, align_type: str, sample: List[str]):
+def alignment(ctx, output_file: Path, reference_name: str, align_type: str,
+              include_variants: List[str], sample: List[str]):
     genomics_index = get_genomics_index(ctx)
     references = genomics_index.reference_names()
     alignment_service = genomics_index.connection.alignment_service
@@ -617,6 +634,7 @@ def alignment(ctx, output_file: Path, reference_name: str, align_type: str, samp
     alignment_data = alignment_service.construct_alignment(reference_name=reference_name,
                                                            samples=query.tolist(names=True),
                                                            align_type=align_type,
+                                                           include_variants=include_variants,
                                                            include_reference=True)
 
     with open(output_file, 'w') as f:
@@ -635,11 +653,13 @@ supported_tree_build_types = ['iqtree']
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
 @click.option('--tree-build-type', help=f'The type of tree building software', default='iqtree',
               type=click.Choice(supported_tree_build_types))
+@click.option('--include-variants', help=f'Which type of variant to include.', default=['SNP'],
+              type=click.Choice(CoreAlignmentService.INCLUDE_VARIANT_TYPES), multiple=True)
 @click.option('--sample', help='Sample to include in tree (can list more than one).',
               multiple=True, type=str)
 @click.option('--extra-params', help='Extra parameters to tree-building software',
               default=None)
-def tree(ctx, output_file: Path, reference_name: str, align_type: str,
+def tree(ctx, output_file: Path, reference_name: str, align_type: str, include_variants: List[str],
          tree_build_type: str, sample: List[str], extra_params: str):
     genomics_index = get_genomics_index(ctx)
     references = genomics_index.reference_names()
@@ -667,6 +687,7 @@ def tree(ctx, output_file: Path, reference_name: str, align_type: str,
                                   align_type=align_type,
                                   scope=reference_name,
                                   include_reference=True,
+                                  include_variants=include_variants,
                                   ncores=ncores,
                                   extra_params=extra_params)
 
@@ -685,9 +706,11 @@ def rebuild(ctx):
 @click.argument('reference', type=str, nargs=-1)
 @click.option('--align-type', help=f'The type of alignment to use for generating the tree', default='core',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
+@click.option('--include-variants', help=f'Which type of variant to include.', default=['SNP'],
+              type=click.Choice(CoreAlignmentService.INCLUDE_VARIANT_TYPES), multiple=True)
 @click.option('--extra-params', help='Extra parameters to tree-building software',
               default=None)
-def rebuild_tree(ctx, reference: List[str], align_type: str, extra_params: str):
+def rebuild_tree(ctx, reference: List[str], align_type: str, include_variants: List[str], extra_params: str):
     data_index_connection = get_project_exit_on_error(ctx).create_connection()
     tree_service = data_index_connection.tree_service
     reference_service = data_index_connection.reference_service
@@ -707,6 +730,7 @@ def rebuild_tree(ctx, reference: List[str], align_type: str, extra_params: str):
         logger.info(f'Started rebuilding tree for reference genome [{reference_name}]')
         tree_service.rebuild_tree(reference_name=reference_name,
                                   align_type=align_type,
+                                  include_variants=include_variants,
                                   num_cores=ncores,
                                   extra_params=extra_params)
         logger.info(f'Finished rebuilding tree')

--- a/genomics_data_index/cli/gdi.py
+++ b/genomics_data_index/cli/gdi.py
@@ -181,7 +181,8 @@ def load_variants_common(data_index_connection: DataIndexConnection, ncores: int
 @click.option('--build-tree/--no-build-tree', default=False, help='Builds tree of all samples after loading')
 @click.option('--align-type', help=f'The type of alignment to generate', default='core',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
-@click.option('--include-variants', help=f'Which type of variant to include in tree.', default=['SNP'],
+@click.option('--include-variants', help=f'Which type of variant to include in tree.',
+              default=CoreAlignmentService.INCLUDE_VARIANT_DEFAULT,
               type=click.Choice(CoreAlignmentService.INCLUDE_VARIANT_TYPES), multiple=True)
 @click.option('--extra-tree-params', help='Extra parameters to tree-building software',
               default=None)
@@ -232,7 +233,8 @@ def load_snippy(ctx, snippy_dir: str, reference_file: str, reference_name: str,
 @click.option('--build-tree/--no-build-tree', default=False, help='Builds tree of all samples after loading')
 @click.option('--align-type', help=f'The type of alignment to generate', default='core',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
-@click.option('--include-variants', help=f'Which type of variant to include in tree.', default=['SNP'],
+@click.option('--include-variants', help=f'Which type of variant to include in tree.',
+              default=CoreAlignmentService.INCLUDE_VARIANT_DEFAULT,
               type=click.Choice(CoreAlignmentService.INCLUDE_VARIANT_TYPES), multiple=True)
 @click.option('--extra-tree-params', help='Extra parameters to tree-building software',
               default=None)
@@ -427,7 +429,8 @@ def input_command(absolute: bool, input_genomes_file: str, genomes: List[str]):
 @click.option('--build-tree/--no-build-tree', default=False, help='Builds tree of all samples after loading')
 @click.option('--align-type', help=f'The type of alignment to generate', default='core',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
-@click.option('--include-variants', help=f'Which type of variant to include in tree.', default=['SNP'],
+@click.option('--include-variants', help=f'Which type of variant to include in tree.',
+              default=CoreAlignmentService.INCLUDE_VARIANT_DEFAULT,
               type=click.Choice(CoreAlignmentService.INCLUDE_VARIANT_TYPES), multiple=True)
 @click.option('--extra-tree-params', help='Extra parameters to tree-building software',
               default=None)
@@ -612,7 +615,8 @@ def build(ctx):
 @click.option('--reference-name', help='Reference genome name', required=True, type=str)
 @click.option('--align-type', help=f'The type of alignment to generate', default='core',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
-@click.option('--include-variants', help=f'Which type of variant to include.', default=['SNP'],
+@click.option('--include-variants', help=f'Which type of variant to include.',
+              default=CoreAlignmentService.INCLUDE_VARIANT_DEFAULT,
               type=click.Choice(CoreAlignmentService.INCLUDE_VARIANT_TYPES), multiple=True)
 @click.option('--sample', help='Sample to include in alignment (can list more than one).',
               multiple=True, type=str)
@@ -656,7 +660,8 @@ supported_tree_build_types = ['iqtree']
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
 @click.option('--tree-build-type', help=f'The type of tree building software', default='iqtree',
               type=click.Choice(supported_tree_build_types))
-@click.option('--include-variants', help=f'Which type of variant to include.', default=['SNP'],
+@click.option('--include-variants', help=f'Which type of variant to include.',
+              default=CoreAlignmentService.INCLUDE_VARIANT_DEFAULT,
               type=click.Choice(CoreAlignmentService.INCLUDE_VARIANT_TYPES), multiple=True)
 @click.option('--sample', help='Sample to include in tree (can list more than one).',
               multiple=True, type=str)
@@ -710,7 +715,8 @@ def rebuild(ctx):
 @click.argument('reference', type=str, nargs=-1)
 @click.option('--align-type', help=f'The type of alignment to use for generating the tree', default='core',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
-@click.option('--include-variants', help=f'Which type of variant to include.', default=['SNP'],
+@click.option('--include-variants', help=f'Which type of variant to include.',
+              default=CoreAlignmentService.INCLUDE_VARIANT_DEFAULT,
               type=click.Choice(CoreAlignmentService.INCLUDE_VARIANT_TYPES), multiple=True)
 @click.option('--extra-params', help='Extra parameters to tree-building software',
               default=None)

--- a/genomics_data_index/storage/service/CoreAlignmentService.py
+++ b/genomics_data_index/storage/service/CoreAlignmentService.py
@@ -134,7 +134,7 @@ class CoreAlignmentService:
         alignments = {}
 
         start_time = time.time()
-        logger.debug(f'Started building alignment for {len(samples)} samples')
+        logger.info(f'Started building alignment for {len(samples)} samples with include_variants={include_variants}')
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             # Write reference genome to file for creating consensus sequences
@@ -207,7 +207,7 @@ class CoreAlignmentService:
             snv_align += alignments[sequence_name]
 
         end_time = time.time()
-        logger.debug(f'Finished building alignment for {len(samples)} samples. '
+        logger.info(f'Finished building alignment for {len(samples)} samples. '
                      f'Took {end_time - start_time:0.2f} seconds')
 
         return snv_align

--- a/genomics_data_index/storage/service/CoreAlignmentService.py
+++ b/genomics_data_index/storage/service/CoreAlignmentService.py
@@ -44,9 +44,9 @@ class CoreAlignmentService:
         return MaskedGenomicRegions.union_all(masked_regions)
 
     def _get_core_positions(self, sample_variations: List[SampleNucleotideVariation],
-                            core_mask: MaskedGenomicRegions) -> Dict[str, List[int]]:
+                            core_mask: MaskedGenomicRegions, include_expression: str) -> Dict[str, List[int]]:
         variation_files = [v.nucleotide_variants_file for v in sample_variations]
-        union_df = VariationFile.union_all_files(variation_files, include_expression='TYPE="SNP"')
+        union_df = VariationFile.union_all_files(variation_files, include_expression=include_expression)
         union_df = union_df.sort_values(['CHROM', 'POS'])
         core_positions = {}
         for index, row in union_df.iterrows():
@@ -69,13 +69,14 @@ class CoreAlignmentService:
         return Seq(sequence_string)
 
     def _core_alignment_sequence_generator(self, reference_file: Path, core_positions: Dict[str, List[int]],
-                                           sample_variations: List[SampleNucleotideVariation]) -> Generator[
+                                           sample_variations: List[SampleNucleotideVariation],
+                                           include_expression: str) -> Generator[
         Dict[str, SeqRecord], None, None]:
         for sample_variation in sample_variations:
             seq_records = {}
 
             consensus_records = VariationFile(sample_variation.nucleotide_variants_file).consensus(
-                reference_file, include_expression='TYPE="SNP"')
+                reference_file, include_expression=include_expression)
             for record in consensus_records:
                 sequence_name = record.id
                 record.id = sample_variation.sample.name
@@ -87,14 +88,15 @@ class CoreAlignmentService:
             yield seq_records
 
     def _full_alignment_sequence_generator(self, reference_file: Path,
-                                           sample_variations: List[SampleNucleotideVariation]) -> Generator[
+                                           sample_variations: List[SampleNucleotideVariation],
+                                           include_expression: str) -> Generator[
         Dict[str, SeqRecord], None, None]:
         for sample_variation in sample_variations:
             seq_records = {}
 
             consensus_records = VariationFile(sample_variation.nucleotide_variants_file).consensus(
                 reference_file=reference_file,
-                include_expression='TYPE="SNP"',
+                include_expression=include_expression,
                 mask_file=sample_variation.masked_regions_file
             )
             for record in consensus_records:
@@ -104,9 +106,14 @@ class CoreAlignmentService:
             yield seq_records
 
     def construct_alignment(self, reference_name: str, samples: List[str] = None,
-                            include_reference: bool = True, align_type: str = 'core') -> MultipleSeqAlignment:
+                            include_reference: bool = True, align_type: str = 'core',
+                            include_expression: str = 'TYPE="SNP"') -> MultipleSeqAlignment:
         if samples is None or len(samples) == 0:
             samples = self._all_sample_names(reference_name)
+
+        if align_type == 'core' and include_expression != 'TYPE="SNP"':
+            raise Exception(f'align_type={align_type} and include_expression={include_expression}. Currently'
+                            f' align_type=core only works with include_expression=\'TYPE="SNP"\'')
 
         sample_nucleotide_variants = self._variation_service.get_sample_nucleotide_variation(samples)
 
@@ -126,12 +133,14 @@ class CoreAlignmentService:
             if align_type == 'core':
                 core_mask = self._create_core_mask(sample_nucleotide_variants)
                 core_positions = self._get_core_positions(sample_variations=sample_nucleotide_variants,
-                                                          core_mask=core_mask)
+                                                          core_mask=core_mask,
+                                                          include_expression=include_expression)
 
                 alignment_generator = self._core_alignment_sequence_generator(
                     reference_file=reference_file,
                     sample_variations=sample_nucleotide_variants,
-                    core_positions=core_positions
+                    core_positions=core_positions,
+                    include_expression=include_expression
                 )
 
                 if include_reference:
@@ -147,7 +156,8 @@ class CoreAlignmentService:
             elif align_type == 'full':
                 alignment_generator = self._full_alignment_sequence_generator(
                     reference_file=reference_file,
-                    sample_variations=sample_nucleotide_variants
+                    sample_variations=sample_nucleotide_variants,
+                    include_expression=include_expression
                 )
 
                 if include_reference:

--- a/genomics_data_index/storage/service/CoreAlignmentService.py
+++ b/genomics_data_index/storage/service/CoreAlignmentService.py
@@ -134,7 +134,7 @@ class CoreAlignmentService:
 
         start_time = time.time()
         logger.info(f'Started building alignment for {len(samples)} samples with include_variants={include_variants}')
-        logger.debug(f'Alignment include_expression={include_expression}')
+        logger.debug(f'Alignment include_expression=\'{include_expression}\'')
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             # Write reference genome to file for creating consensus sequences

--- a/genomics_data_index/storage/service/CoreAlignmentService.py
+++ b/genomics_data_index/storage/service/CoreAlignmentService.py
@@ -120,13 +120,12 @@ class CoreAlignmentService:
             raise Exception(f'align_type={align_type} and include_variants={include_variants}. Currently'
                             f' align_type=core only works with include_variants=["SNP"]')
         else:
-            include_expression = ''
             for variant in include_variants:
                 if variant not in self.INCLUDE_VARIANT_TYPES:
                     raise Exception(f'variant={variant} found in include_variants={include_variants}. '
                                     f'Only {self.INCLUDE_VARIANT_TYPES} are supported')
-                else:
-                    include_expression += f'(TYPE=="{variant}")'
+
+        include_expression = ' | '.join(f'(TYPE=="{variant}")' for variant in include_variants)
 
         sample_nucleotide_variants = self._variation_service.get_sample_nucleotide_variation(samples)
 
@@ -135,6 +134,7 @@ class CoreAlignmentService:
 
         start_time = time.time()
         logger.info(f'Started building alignment for {len(samples)} samples with include_variants={include_variants}')
+        logger.debug(f'Alignment include_expression={include_expression}')
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             # Write reference genome to file for creating consensus sequences

--- a/genomics_data_index/storage/service/CoreAlignmentService.py
+++ b/genomics_data_index/storage/service/CoreAlignmentService.py
@@ -3,7 +3,7 @@ import logging
 import tempfile
 import time
 from pathlib import Path
-from typing import List, Dict, Generator, Tuple
+from typing import List, Dict, Generator
 
 from Bio import SeqIO
 from Bio.Align import MultipleSeqAlignment
@@ -208,6 +208,6 @@ class CoreAlignmentService:
 
         end_time = time.time()
         logger.info(f'Finished building alignment for {len(samples)} samples. '
-                     f'Took {end_time - start_time:0.2f} seconds')
+                    f'Took {end_time - start_time:0.2f} seconds')
 
         return snv_align

--- a/genomics_data_index/storage/service/CoreAlignmentService.py
+++ b/genomics_data_index/storage/service/CoreAlignmentService.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 class CoreAlignmentService:
     ALIGN_TYPES = ['core', 'full']
-    INCLUDE_VARIANT_TYPES = ['SNP', 'MNP', 'INDEL', 'OTHER']
+    INCLUDE_VARIANT_TYPES = ['SNP', 'MNP']
     INCLUDE_VARIANT_DEFAULT = ['SNP']
 
     # Mask generated sequence with this character (which should not appear anywhere else) so I can remove

--- a/genomics_data_index/storage/service/TreeService.py
+++ b/genomics_data_index/storage/service/TreeService.py
@@ -2,7 +2,7 @@ import logging
 import subprocess
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Tuple
+from typing import Tuple, List
 
 from Bio import AlignIO
 from Bio.Align import MultipleSeqAlignment
@@ -88,10 +88,11 @@ class TreeService:
                 raise Exception(f'tree_type=[{tree_build_type}] is invalid')
 
     def rebuild_tree(self, reference_name: str, num_cores: int = 1, tree_build_type='iqtree',
-                     align_type='core', extra_params=None):
+                     align_type='core', include_variants: List[str] = None, extra_params=None):
         logger.debug('Building alignment')
         alignment = self._core_alignment_service.construct_alignment(reference_name=reference_name,
                                                                      include_reference=True,
+                                                                     include_variants=include_variants,
                                                                      align_type=align_type)
 
         logger.debug('Building tree')

--- a/genomics_data_index/test/integration/api/query/features/test_MutationFromIndexFeaturesComparator.py
+++ b/genomics_data_index/test/integration/api/query/features/test_MutationFromIndexFeaturesComparator.py
@@ -23,6 +23,7 @@ def test_summary_all(loaded_database_genomic_data_store: GenomicsDataIndex):
         'Position': 'first',
         'Deletion': 'first',
         'Insertion': 'first',
+        'Type': 'first',
         'Mutation': 'count',
     }).rename(columns={'Mutation': 'Count'}).sort_index()
     expected_df['Total'] = 9
@@ -46,6 +47,7 @@ def test_summary_all(loaded_database_genomic_data_store: GenomicsDataIndex):
     assert list(expected_df['Deletion']) == list(mutations_df['Deletion'])
     assert list(expected_df['Count']) == list(mutations_df['Count'])
     assert list(expected_df['Total']) == list(mutations_df['Total'])
+    assert list(expected_df['Type']) == list(mutations_df['Type'])
     assert 22 == mutations_df.loc['reference:619:G:C', 'Percent']
 
     # Test with unknown
@@ -58,12 +60,19 @@ def test_summary_all(loaded_database_genomic_data_store: GenomicsDataIndex):
     assert 632 == len(mutations_df)
     assert list(expected_df.columns) == list(mutations_df.columns)
     assert 2 == mutations_df.loc['reference:619:G:C', 'Count']
+    assert 'SNP' == mutations_df.loc['reference:619:G:C', 'Type']
     assert 2 == mutations_df.loc['reference:3063:A:ATGCAGC', 'Count']
+    assert 'INDEL' == mutations_df.loc['reference:3063:A:ATGCAGC', 'Type']
     assert 1 == mutations_df.loc['reference:1984:GTGATTG:TTGA', 'Count']
+    assert 'OTHER' == mutations_df.loc['reference:1984:GTGATTG:TTGA', 'Type']
     assert 1 == mutations_df.loc['reference:866:GCCAGATCC:G', 'Count']
+    assert 'INDEL' == mutations_df.loc['reference:866:GCCAGATCC:G', 'Type']
     assert 3 == mutations_df.loc['reference:90:T:?', 'Count']
+    assert 'UNKNOWN_MISSING' == mutations_df.loc['reference:90:T:?', 'Type']
     assert 2 == mutations_df.loc['reference:190:A:?', 'Count']
+    assert 'UNKNOWN_MISSING' == mutations_df.loc['reference:190:A:?', 'Type']
     assert 1 == mutations_df.loc['reference:887:T:?', 'Count']
+    assert 'UNKNOWN_MISSING' == mutations_df.loc['reference:887:T:?', 'Type']
 
     # Test only include unknown
     mutations_summarizer = MutationFeaturesFromIndexComparator(connection=loaded_database_genomic_data_store.connection,
@@ -76,8 +85,11 @@ def test_summary_all(loaded_database_genomic_data_store: GenomicsDataIndex):
     assert 521 == len(mutations_df)
     assert list(expected_df.columns) == list(mutations_df.columns)
     assert 3 == mutations_df.loc['reference:90:T:?', 'Count']
+    assert 'UNKNOWN_MISSING' == mutations_df.loc['reference:90:T:?', 'Type']
     assert 2 == mutations_df.loc['reference:190:A:?', 'Count']
+    assert 'UNKNOWN_MISSING' == mutations_df.loc['reference:190:A:?', 'Type']
     assert 1 == mutations_df.loc['reference:887:T:?', 'Count']
+    assert 'UNKNOWN_MISSING' == mutations_df.loc['reference:887:T:?', 'Type']
     assert 'reference:619:G:C' not in mutations_df
 
     # Test with different id type where deletion is int instead of sequence
@@ -90,9 +102,13 @@ def test_summary_all(loaded_database_genomic_data_store: GenomicsDataIndex):
     assert 112 - 1 == len(mutations_df)
     assert list(expected_df.columns) == list(mutations_df.columns)
     assert 2 == mutations_df.loc['reference:619:1:C', 'Count']
+    assert 'SNP' == mutations_df.loc['reference:619:1:C', 'Type']
     assert 2 == mutations_df.loc['reference:3063:1:ATGCAGC', 'Count']
+    assert 'INDEL' == mutations_df.loc['reference:3063:1:ATGCAGC', 'Type']
     assert 1 == mutations_df.loc['reference:1984:7:TTGA', 'Count']
+    assert 'OTHER' == mutations_df.loc['reference:1984:7:TTGA', 'Type']
     assert 1 == mutations_df.loc['reference:866:9:G', 'Count']
+    assert 'INDEL' == mutations_df.loc['reference:866:9:G', 'Type']
 
     # Test with different id type include unknown
     mutations_summarizer = MutationFeaturesFromIndexComparator(connection=loaded_database_genomic_data_store.connection,
@@ -105,12 +121,19 @@ def test_summary_all(loaded_database_genomic_data_store: GenomicsDataIndex):
     assert 632 == len(mutations_df)
     assert list(expected_df.columns) == list(mutations_df.columns)
     assert 2 == mutations_df.loc['reference:619:1:C', 'Count']
+    assert 'SNP' == mutations_df.loc['reference:619:1:C', 'Type']
     assert 2 == mutations_df.loc['reference:3063:1:ATGCAGC', 'Count']
+    assert 'INDEL' == mutations_df.loc['reference:3063:1:ATGCAGC', 'Type']
     assert 1 == mutations_df.loc['reference:1984:7:TTGA', 'Count']
+    assert 'OTHER' == mutations_df.loc['reference:1984:7:TTGA', 'Type']
     assert 1 == mutations_df.loc['reference:866:9:G', 'Count']
+    assert 'INDEL' == mutations_df.loc['reference:866:9:G', 'Type']
     assert 3 == mutations_df.loc['reference:90:1:?', 'Count']
+    assert 'UNKNOWN_MISSING' == mutations_df.loc['reference:90:1:?', 'Type']
     assert 2 == mutations_df.loc['reference:190:1:?', 'Count']
+    assert 'UNKNOWN_MISSING' == mutations_df.loc['reference:190:1:?', 'Type']
     assert 1 == mutations_df.loc['reference:887:1:?', 'Count']
+    assert 'UNKNOWN_MISSING' == mutations_df.loc['reference:887:1:?', 'Type']
 
 
 def test_summary_unique(loaded_database_genomic_data_store: GenomicsDataIndex):
@@ -138,6 +161,7 @@ def test_summary_unique(loaded_database_genomic_data_store: GenomicsDataIndex):
         'Position': 'first',
         'Deletion': 'first',
         'Insertion': 'first',
+        'Type': 'first',
         'Mutation': 'count',
     }).rename(columns={'Mutation': 'Count'}).sort_index()
     expected_df['Total'] = 1
@@ -168,6 +192,7 @@ def test_summary_unique(loaded_database_genomic_data_store: GenomicsDataIndex):
         'Position': 'first',
         'Deletion': 'first',
         'Insertion': 'first',
+        'Type': 'first',
         'Mutation': 'count',
     }).rename(columns={'Mutation': 'Count'}).sort_index()
     expected_df['Total'] = 1
@@ -193,6 +218,7 @@ def test_summary_unique(loaded_database_genomic_data_store: GenomicsDataIndex):
         'Position': 'first',
         'Deletion': 'first',
         'Insertion': 'first',
+        'Type': 'first',
         'Mutation': 'count',
     }).rename(columns={'Mutation': 'Count'}).sort_index()
     expected_df['Total'] = 2
@@ -225,7 +251,7 @@ def test_summary_annotations(loaded_database_genomic_data_store_annotations: Gen
     present_set = SampleSet(three_samples)
     mutations_df = mutations_summarizer.summary(present_set)
 
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Count', 'Total', 'Percent', 'Annotation', 'Annotation_Impact',
             'Gene_Name', 'Gene_ID', 'Feature_Type', 'Transcript_BioType',
             'HGVS.c', 'HGVS.p', 'ID_HGVS.c', 'ID_HGVS.p', 'ID_HGVS_GN.c', 'ID_HGVS_GN.p'] == list(mutations_df.columns)
@@ -233,7 +259,7 @@ def test_summary_annotations(loaded_database_genomic_data_store_annotations: Gen
     mutations_df['Percent'] = mutations_df['Percent'].astype(int)  # easier to compare percents in assert
 
     # missense variant (3/3)
-    assert ['NC_011083', 140658, 'C', 'A', 3, 3, 100,
+    assert ['NC_011083', 140658, 'C', 'A', 'SNP', 3, 3, 100,
             'missense_variant', 'MODERATE', 'murF', 'SEHA_RS01180', 'transcript', 'protein_coding',
             'c.497C>A', 'p.Ala166Glu',
             'hgvs:NC_011083:SEHA_RS01180:c.497C>A', 'hgvs:NC_011083:SEHA_RS01180:p.Ala166Glu',
@@ -241,7 +267,7 @@ def test_summary_annotations(loaded_database_genomic_data_store_annotations: Gen
         mutations_df.loc['NC_011083:140658:C:A'])
 
     # Intergenic variant (1/3)
-    assert ['NC_011083', 4555461, 'T', 'TC', 1, 3, 33,
+    assert ['NC_011083', 4555461, 'T', 'TC', 'INDEL', 1, 3, 33,
             'intergenic_region', 'MODIFIER', 'SEHA_RS22510-SEHA_RS26685', 'SEHA_RS22510-SEHA_RS26685',
             'intergenic_region', 'NA',
             'n.4555461_4555462insC', 'NA',
@@ -270,13 +296,16 @@ def test_features_comparison(loaded_database_genomic_data_store: GenomicsDataInd
                                                              unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Total', 'All_count', 'All_total'] == comparison_df.columns.tolist()
     assert {9} == set(comparison_df['Total'].tolist())
     assert {9} == set(comparison_df['All_total'].tolist())
     assert 2 == comparison_df.loc['reference:619:G:C', 'All_count']
+    assert 'SNP' == comparison_df.loc['reference:619:G:C', 'Type']
     assert 1 == comparison_df.loc['reference:1708:ATGCTGTTCAATAC:A', 'All_count']
+    assert 'INDEL' == comparison_df.loc['reference:1708:ATGCTGTTCAATAC:A', 'Type']
     assert 2 == comparison_df.loc['reference:4693:C:CGA', 'All_count']
+    assert 'INDEL' == comparison_df.loc['reference:4693:C:CGA', 'Type']
 
     # Test two categories, one of A and one of BC
     sample_categories = [SampleSet([sampleA.id]), SampleSet([sampleB.id, sampleC.id])]
@@ -286,7 +315,7 @@ def test_features_comparison(loaded_database_genomic_data_store: GenomicsDataInd
                                                              unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Total', 'A_count', 'BC_count', 'A_total', 'BC_total'] == comparison_df.columns.tolist()
     assert {9} == set(comparison_df['Total'].tolist())
     assert {1} == set(comparison_df['A_total'].tolist())
@@ -306,7 +335,7 @@ def test_features_comparison(loaded_database_genomic_data_store: GenomicsDataInd
                                                              unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Total', 'AB_count', 'C_count', 'AB_total', 'C_total'] == comparison_df.columns.tolist()
     assert {9} == set(comparison_df['Total'].tolist())
     assert {2} == set(comparison_df['AB_total'].tolist())
@@ -329,7 +358,7 @@ def test_features_comparison(loaded_database_genomic_data_store: GenomicsDataInd
                                                              unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Total',
             'A_count', 'B_count', 'C_count',
             'A_total', 'B_total', 'C_total'] == comparison_df.columns.tolist()
@@ -360,7 +389,7 @@ def test_features_comparison(loaded_database_genomic_data_store: GenomicsDataInd
     comparison_df['A_percent'] = comparison_df['A_percent'].astype(int)  # Convert to int for easier comparison
     comparison_df['BC_percent'] = comparison_df['BC_percent'].astype(int)  # Convert to int for easier comparison
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Total', 'A_percent', 'BC_percent', 'A_total', 'BC_total'] == comparison_df.columns.tolist()
     assert {9} == set(comparison_df['Total'].tolist())
     assert {1} == set(comparison_df['A_total'].tolist())
@@ -382,7 +411,7 @@ def test_features_comparison(loaded_database_genomic_data_store: GenomicsDataInd
     comparison_df['Category2_percent'] = comparison_df['Category2_percent'].astype(
         int)  # Convert to int for easier comparison
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Total',
             'Category1_percent', 'Category2_percent',
             'Category1_total', 'Category2_total'] == comparison_df.columns.tolist()
@@ -418,7 +447,7 @@ def test_features_comparison_annotations(loaded_database_genomic_data_store_anno
                                                              unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Total',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Total',
             'All_count',
             'All_total',
             'Annotation', 'Annotation_Impact',
@@ -443,7 +472,7 @@ def test_features_comparison_annotations(loaded_database_genomic_data_store_anno
                                                              unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Total',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Total',
             '10_count', '14_count',
             '10_total', '14_total',
             'Annotation', 'Annotation_Impact',
@@ -481,7 +510,7 @@ def test_features_comparison_annotations(loaded_database_genomic_data_store_anno
     comparison_df['Category2_percent'] = comparison_df['Category2_percent'].astype(
         int)  # Convert to int for easier comparison
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Total',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Total',
             'Category1_percent', 'Category2_percent',
             'Category1_total', 'Category2_total',
             'Annotation', 'Annotation_Impact',
@@ -518,7 +547,7 @@ def test_features_comparison_annotations(loaded_database_genomic_data_store_anno
                                                              unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Total',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Total',
             '10_count', '14_count',
             '10_total', '14_total',
             'Annotation', 'Annotation_Impact',
@@ -555,7 +584,7 @@ def test_features_comparison_annotations(loaded_database_genomic_data_store_anno
                                                              unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Total',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Total',
             '14_count',
             '14_total',
             'Annotation', 'Annotation_Impact',

--- a/genomics_data_index/test/integration/api/query/features/test_MutationFromIndexFeaturesComparator.py
+++ b/genomics_data_index/test/integration/api/query/features/test_MutationFromIndexFeaturesComparator.py
@@ -275,6 +275,15 @@ def test_summary_annotations(loaded_database_genomic_data_store_annotations: Gen
             'hgvs_gn:NC_011083:n.4555461_4555462insC', 'NA'] == list(
         mutations_df.loc['NC_011083:4555461:T:TC'].fillna('NA'))
 
+    # MNP variant (1/3)
+    assert ['NC_011083', 3535698, 'GCC', 'CAT', 'MNP', 2, 3, 66,
+            'missense_variant', 'MODERATE', 'oadA', 'SEHA_RS17780',
+            'transcript', 'protein_coding',
+            'c.544_546delGGCinsATG', 'p.Gly182Met',
+            'hgvs:NC_011083:SEHA_RS17780:c.544_546delGGCinsATG', 'hgvs:NC_011083:SEHA_RS17780:p.Gly182Met',
+            'hgvs_gn:NC_011083:oadA:c.544_546delGGCinsATG', 'hgvs_gn:NC_011083:oadA:p.Gly182Met'] == list(
+        mutations_df.loc['NC_011083:3535698:GCC:CAT'])
+
 
 def test_features_comparison(loaded_database_genomic_data_store: GenomicsDataIndex):
     db = loaded_database_genomic_data_store.connection.database

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex.py
@@ -87,7 +87,8 @@ def test_summaries_loaded_data(loaded_database_genomic_data_store: GenomicsDataI
     ms['Percent'] = ms['Percent'].astype(int)
 
     assert ['reference', 839, 'C', 'G', 'SNP', 2, 3, 66] == ms.loc['reference:839:C:G'].values.tolist()
-    assert ['reference', 866, 'GCCAGATCC', 'G', 'INDEL', 1, 3, 33] == ms.loc['reference:866:GCCAGATCC:G'].values.tolist()
+    assert ['reference', 866, 'GCCAGATCC', 'G', 'INDEL', 1, 3, 33] == ms.loc[
+        'reference:866:GCCAGATCC:G'].values.tolist()
     assert ['reference', 1048, 'C', 'G', 'SNP', 1, 3, 33] == ms.loc['reference:1048:C:G'].values.tolist()
     assert ['reference', 3897, 'GCGCA', 'G', 'INDEL', 2, 3, 66] == ms.loc['reference:3897:GCGCA:G'].values.tolist()
 
@@ -101,7 +102,8 @@ def test_summaries_loaded_data(loaded_database_genomic_data_store: GenomicsDataI
     ms['Percent'] = ms['Percent'].astype(int)
 
     assert ['reference', 839, 'C', 'G', 'SNP', 2, 3, 66] == ms.loc['reference:839:C:G'].values.tolist()
-    assert ['reference', 866, 'GCCAGATCC', 'G', 'INDEL', 1, 3, 33] == ms.loc['reference:866:GCCAGATCC:G'].values.tolist()
+    assert ['reference', 866, 'GCCAGATCC', 'G', 'INDEL', 1, 3, 33] == ms.loc[
+        'reference:866:GCCAGATCC:G'].values.tolist()
     assert ['reference', 1048, 'C', 'G', 'SNP', 1, 3, 33] == ms.loc['reference:1048:C:G'].values.tolist()
     assert ['reference', 3897, 'GCGCA', 'G', 'INDEL', 2, 3, 66] == ms.loc['reference:3897:GCGCA:G'].values.tolist()
     assert ['reference', 89, 'A', '?', 'UNKNOWN_MISSING', 3, 3, 100] == ms.loc['reference:89:A:?'].values.tolist()

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex.py
@@ -50,69 +50,69 @@ def test_summaries_loaded_data(loaded_database_genomic_data_store: GenomicsDataI
     ms = gds.mutations_summary('genome', id_type='spdi', ignore_annotations=True)
     assert 111 == len(ms)
     assert 'Mutation' == ms.index.name
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Count', 'Total', 'Percent'] == list(ms.columns)
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Count', 'Total', 'Percent'] == list(ms.columns)
 
     ## Convert percent to int to make it easier to compare in assert statements
     ms['Percent'] = ms['Percent'].astype(int)
 
-    assert ['reference', 839, 1, 'G', 2, 3, 66] == ms.loc['reference:839:1:G'].values.tolist()
-    assert ['reference', 866, 9, 'G', 1, 3, 33] == ms.loc['reference:866:9:G'].values.tolist()
-    assert ['reference', 1048, 1, 'G', 1, 3, 33] == ms.loc['reference:1048:1:G'].values.tolist()
-    assert ['reference', 3897, 5, 'G', 2, 3, 66] == ms.loc['reference:3897:5:G'].values.tolist()
+    assert ['reference', 839, 1, 'G', 'SNP', 2, 3, 66] == ms.loc['reference:839:1:G'].values.tolist()
+    assert ['reference', 866, 9, 'G', 'INDEL', 1, 3, 33] == ms.loc['reference:866:9:G'].values.tolist()
+    assert ['reference', 1048, 1, 'G', 'SNP', 1, 3, 33] == ms.loc['reference:1048:1:G'].values.tolist()
+    assert ['reference', 3897, 5, 'G', 'INDEL', 2, 3, 66] == ms.loc['reference:3897:5:G'].values.tolist()
 
     # Mutations include unknown spdi
     ms = gds.mutations_summary('genome', id_type='spdi', ignore_annotations=True, include_unknown=True)
     assert 632 == len(ms)
     assert 'Mutation' == ms.index.name
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Count', 'Total', 'Percent'] == list(ms.columns)
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Count', 'Total', 'Percent'] == list(ms.columns)
 
     ## Convert percent to int to make it easier to compare in assert statements
     ms['Percent'] = ms['Percent'].astype(int)
 
-    assert ['reference', 839, 1, 'G', 2, 3, 66] == ms.loc['reference:839:1:G'].values.tolist()
-    assert ['reference', 866, 9, 'G', 1, 3, 33] == ms.loc['reference:866:9:G'].values.tolist()
-    assert ['reference', 1048, 1, 'G', 1, 3, 33] == ms.loc['reference:1048:1:G'].values.tolist()
-    assert ['reference', 3897, 5, 'G', 2, 3, 66] == ms.loc['reference:3897:5:G'].values.tolist()
-    assert ['reference', 89, 1, '?', 3, 3, 100] == ms.loc['reference:89:1:?'].values.tolist()
-    assert ['reference', 5100, 1, '?', 2, 3, 66] == ms.loc['reference:5100:1:?'].values.tolist()
-    assert ['reference', 649, 1, '?', 1, 3, 33] == ms.loc['reference:649:1:?'].values.tolist()
+    assert ['reference', 839, 1, 'G', 'SNP', 2, 3, 66] == ms.loc['reference:839:1:G'].values.tolist()
+    assert ['reference', 866, 9, 'G', 'INDEL', 1, 3, 33] == ms.loc['reference:866:9:G'].values.tolist()
+    assert ['reference', 1048, 1, 'G', 'SNP', 1, 3, 33] == ms.loc['reference:1048:1:G'].values.tolist()
+    assert ['reference', 3897, 5, 'G', 'INDEL', 2, 3, 66] == ms.loc['reference:3897:5:G'].values.tolist()
+    assert ['reference', 89, 1, '?', 'UNKNOWN_MISSING', 3, 3, 100] == ms.loc['reference:89:1:?'].values.tolist()
+    assert ['reference', 5100, 1, '?', 'UNKNOWN_MISSING', 2, 3, 66] == ms.loc['reference:5100:1:?'].values.tolist()
+    assert ['reference', 649, 1, '?', 'UNKNOWN_MISSING', 1, 3, 33] == ms.loc['reference:649:1:?'].values.tolist()
 
     # Mutations spdi ref
     ms = gds.mutations_summary('genome', id_type='spdi_ref', ignore_annotations=True)
     assert 111 == len(ms)
     assert 'Mutation' == ms.index.name
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Count', 'Total', 'Percent'] == list(ms.columns)
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Count', 'Total', 'Percent'] == list(ms.columns)
 
     ## Convert percent to int to make it easier to compare in assert statements
     ms['Percent'] = ms['Percent'].astype(int)
 
-    assert ['reference', 839, 'C', 'G', 2, 3, 66] == ms.loc['reference:839:C:G'].values.tolist()
-    assert ['reference', 866, 'GCCAGATCC', 'G', 1, 3, 33] == ms.loc['reference:866:GCCAGATCC:G'].values.tolist()
-    assert ['reference', 1048, 'C', 'G', 1, 3, 33] == ms.loc['reference:1048:C:G'].values.tolist()
-    assert ['reference', 3897, 'GCGCA', 'G', 2, 3, 66] == ms.loc['reference:3897:GCGCA:G'].values.tolist()
+    assert ['reference', 839, 'C', 'G', 'SNP', 2, 3, 66] == ms.loc['reference:839:C:G'].values.tolist()
+    assert ['reference', 866, 'GCCAGATCC', 'G', 'INDEL', 1, 3, 33] == ms.loc['reference:866:GCCAGATCC:G'].values.tolist()
+    assert ['reference', 1048, 'C', 'G', 'SNP', 1, 3, 33] == ms.loc['reference:1048:C:G'].values.tolist()
+    assert ['reference', 3897, 'GCGCA', 'G', 'INDEL', 2, 3, 66] == ms.loc['reference:3897:GCGCA:G'].values.tolist()
 
     # Mutations spdi ref include unknowns
     ms = gds.mutations_summary('genome', id_type='spdi_ref', ignore_annotations=True, include_unknown=True)
     assert 632 == len(ms)
     assert 'Mutation' == ms.index.name
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Count', 'Total', 'Percent'] == list(ms.columns)
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Count', 'Total', 'Percent'] == list(ms.columns)
 
     ## Convert percent to int to make it easier to compare in assert statements
     ms['Percent'] = ms['Percent'].astype(int)
 
-    assert ['reference', 839, 'C', 'G', 2, 3, 66] == ms.loc['reference:839:C:G'].values.tolist()
-    assert ['reference', 866, 'GCCAGATCC', 'G', 1, 3, 33] == ms.loc['reference:866:GCCAGATCC:G'].values.tolist()
-    assert ['reference', 1048, 'C', 'G', 1, 3, 33] == ms.loc['reference:1048:C:G'].values.tolist()
-    assert ['reference', 3897, 'GCGCA', 'G', 2, 3, 66] == ms.loc['reference:3897:GCGCA:G'].values.tolist()
-    assert ['reference', 89, 'A', '?', 3, 3, 100] == ms.loc['reference:89:A:?'].values.tolist()
-    assert ['reference', 5100, 'T', '?', 2, 3, 66] == ms.loc['reference:5100:T:?'].values.tolist()
-    assert ['reference', 649, 'T', '?', 1, 3, 33] == ms.loc['reference:649:T:?'].values.tolist()
+    assert ['reference', 839, 'C', 'G', 'SNP', 2, 3, 66] == ms.loc['reference:839:C:G'].values.tolist()
+    assert ['reference', 866, 'GCCAGATCC', 'G', 'INDEL', 1, 3, 33] == ms.loc['reference:866:GCCAGATCC:G'].values.tolist()
+    assert ['reference', 1048, 'C', 'G', 'SNP', 1, 3, 33] == ms.loc['reference:1048:C:G'].values.tolist()
+    assert ['reference', 3897, 'GCGCA', 'G', 'INDEL', 2, 3, 66] == ms.loc['reference:3897:GCGCA:G'].values.tolist()
+    assert ['reference', 89, 'A', '?', 'UNKNOWN_MISSING', 3, 3, 100] == ms.loc['reference:89:A:?'].values.tolist()
+    assert ['reference', 5100, 'T', '?', 'UNKNOWN_MISSING', 2, 3, 66] == ms.loc['reference:5100:T:?'].values.tolist()
+    assert ['reference', 649, 'T', '?', 'UNKNOWN_MISSING', 1, 3, 33] == ms.loc['reference:649:T:?'].values.tolist()
 
     # Mutations include annotations (which should all be empty)
     ms = gds.mutations_summary('genome', id_type='spdi', ignore_annotations=False)
     assert 111 == len(ms)
     assert 'Mutation' == ms.index.name
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Count', 'Total', 'Percent', 'Annotation', 'Annotation_Impact',
             'Gene_Name', 'Gene_ID', 'Feature_Type', 'Transcript_BioType',
             'HGVS.c', 'HGVS.p', 'ID_HGVS.c', 'ID_HGVS.p', 'ID_HGVS_GN.c', 'ID_HGVS_GN.p'] == list(ms.columns)
@@ -120,22 +120,22 @@ def test_summaries_loaded_data(loaded_database_genomic_data_store: GenomicsDataI
     ## Convert percent to int to make it easier to compare in assert statements
     ms['Percent'] = ms['Percent'].astype(int)
 
-    assert ['reference', 839, 1, 'G', 2, 3, 66] + ['NA'] * 12 == ms.loc['reference:839:1:G'].fillna(
+    assert ['reference', 839, 1, 'G', 'SNP', 2, 3, 66] + ['NA'] * 12 == ms.loc['reference:839:1:G'].fillna(
         'NA').values.tolist()
 
     # Test case of directly calling features_summary
     ms = gds.features_summary(kind='mutations', scope='genome', id_type='spdi', ignore_annotations=True)
     assert 111 == len(ms)
     assert 'Mutation' == ms.index.name
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Count', 'Total', 'Percent'] == list(ms.columns)
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Count', 'Total', 'Percent'] == list(ms.columns)
 
     ## Convert percent to int to make it easier to compare in assert statements
     ms['Percent'] = ms['Percent'].astype(int)
 
-    assert ['reference', 839, 1, 'G', 2, 3, 66] == ms.loc['reference:839:1:G'].values.tolist()
-    assert ['reference', 866, 9, 'G', 1, 3, 33] == ms.loc['reference:866:9:G'].values.tolist()
-    assert ['reference', 1048, 1, 'G', 1, 3, 33] == ms.loc['reference:1048:1:G'].values.tolist()
-    assert ['reference', 3897, 5, 'G', 2, 3, 66] == ms.loc['reference:3897:5:G'].values.tolist()
+    assert ['reference', 839, 1, 'G', 'SNP', 2, 3, 66] == ms.loc['reference:839:1:G'].values.tolist()
+    assert ['reference', 866, 9, 'G', 'INDEL', 1, 3, 33] == ms.loc['reference:866:9:G'].values.tolist()
+    assert ['reference', 1048, 1, 'G', 'SNP', 1, 3, 33] == ms.loc['reference:1048:1:G'].values.tolist()
+    assert ['reference', 3897, 5, 'G', 'INDEL', 2, 3, 66] == ms.loc['reference:3897:5:G'].values.tolist()
 
     # Test case of only including unknowns
     ms = gds.mutations_summary('genome', id_type='spdi', include_present=False, include_unknown=True)
@@ -223,7 +223,7 @@ def test_summaries_variant_annotations(loaded_database_genomic_data_store_annota
     ms = gds.mutations_summary('NC_011083', id_type='spdi', ignore_annotations=False)
     assert 177 == len(ms)
     assert 'Mutation' == ms.index.name
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Count', 'Total', 'Percent', 'Annotation', 'Annotation_Impact',
             'Gene_Name', 'Gene_ID', 'Feature_Type', 'Transcript_BioType',
             'HGVS.c', 'HGVS.p', 'ID_HGVS.c', 'ID_HGVS.p', 'ID_HGVS_GN.c', 'ID_HGVS_GN.p'] == list(ms.columns)
@@ -232,7 +232,7 @@ def test_summaries_variant_annotations(loaded_database_genomic_data_store_annota
     ms['Percent'] = ms['Percent'].astype(int)
 
     ## missense variant
-    assert ['NC_011083', 140658, 1, 'A', 3, 3, 100,
+    assert ['NC_011083', 140658, 1, 'A', 'SNP', 3, 3, 100,
             'missense_variant', 'MODERATE', 'murF', 'SEHA_RS01180', 'transcript', 'protein_coding',
             'c.497C>A', 'p.Ala166Glu',
             'hgvs:NC_011083:SEHA_RS01180:c.497C>A', 'hgvs:NC_011083:SEHA_RS01180:p.Ala166Glu',
@@ -240,7 +240,7 @@ def test_summaries_variant_annotations(loaded_database_genomic_data_store_annota
         ms.loc['NC_011083:140658:1:A'])
 
     ## inframe deletion
-    assert ['NC_011083', 4465400, len('GGCCGAA'), 'G', 3, 3, 100,
+    assert ['NC_011083', 4465400, len('GGCCGAA'), 'G', 'INDEL', 3, 3, 100,
             'conservative_inframe_deletion', 'MODERATE', 'tyrB', 'SEHA_RS22180', 'transcript', 'protein_coding',
             'c.157_162delGAAGCC', 'p.Glu53_Ala54del',
             'hgvs:NC_011083:SEHA_RS22180:c.157_162delGAAGCC', 'hgvs:NC_011083:SEHA_RS22180:p.Glu53_Ala54del',
@@ -248,7 +248,7 @@ def test_summaries_variant_annotations(loaded_database_genomic_data_store_annota
         ms.loc['NC_011083:4465400:7:G'])
 
     ## Intergenic variant (with some NA values in fields)
-    assert ['NC_011083', 4555461, len('T'), 'TC', 1, 3, 33,
+    assert ['NC_011083', 4555461, len('T'), 'TC', 'INDEL', 1, 3, 33,
             'intergenic_region', 'MODIFIER', 'SEHA_RS22510-SEHA_RS26685', 'SEHA_RS22510-SEHA_RS26685',
             'intergenic_region', 'NA',
             'n.4555461_4555462insC', 'NA',
@@ -259,7 +259,7 @@ def test_summaries_variant_annotations(loaded_database_genomic_data_store_annota
     ms = gds.mutations_summary('NC_011083', id_type='spdi_ref')
     assert 177 == len(ms)
     assert 'Mutation' == ms.index.name
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Count', 'Total', 'Percent', 'Annotation', 'Annotation_Impact',
             'Gene_Name', 'Gene_ID', 'Feature_Type', 'Transcript_BioType',
             'HGVS.c', 'HGVS.p', 'ID_HGVS.c', 'ID_HGVS.p', 'ID_HGVS_GN.c', 'ID_HGVS_GN.p'] == list(ms.columns)
@@ -268,7 +268,7 @@ def test_summaries_variant_annotations(loaded_database_genomic_data_store_annota
     ms['Percent'] = ms['Percent'].astype(int)
 
     ## missense variant
-    assert ['NC_011083', 140658, 'C', 'A', 3, 3, 100,
+    assert ['NC_011083', 140658, 'C', 'A', 'SNP', 3, 3, 100,
             'missense_variant', 'MODERATE', 'murF', 'SEHA_RS01180', 'transcript', 'protein_coding',
             'c.497C>A', 'p.Ala166Glu',
             'hgvs:NC_011083:SEHA_RS01180:c.497C>A', 'hgvs:NC_011083:SEHA_RS01180:p.Ala166Glu',
@@ -276,7 +276,7 @@ def test_summaries_variant_annotations(loaded_database_genomic_data_store_annota
         ms.loc['NC_011083:140658:C:A'])
 
     ## inframe deletion
-    assert ['NC_011083', 4465400, 'GGCCGAA', 'G', 3, 3, 100,
+    assert ['NC_011083', 4465400, 'GGCCGAA', 'G', 'INDEL', 3, 3, 100,
             'conservative_inframe_deletion', 'MODERATE', 'tyrB', 'SEHA_RS22180', 'transcript', 'protein_coding',
             'c.157_162delGAAGCC', 'p.Glu53_Ala54del',
             'hgvs:NC_011083:SEHA_RS22180:c.157_162delGAAGCC', 'hgvs:NC_011083:SEHA_RS22180:p.Glu53_Ala54del',
@@ -284,7 +284,7 @@ def test_summaries_variant_annotations(loaded_database_genomic_data_store_annota
         ms.loc['NC_011083:4465400:GGCCGAA:G'])
 
     ## Intergenic variant (with some NA values in fields)
-    assert ['NC_011083', 4555461, 'T', 'TC', 1, 3, 33,
+    assert ['NC_011083', 4555461, 'T', 'TC', 'INDEL', 1, 3, 33,
             'intergenic_region', 'MODIFIER', 'SEHA_RS22510-SEHA_RS26685', 'SEHA_RS22510-SEHA_RS26685',
             'intergenic_region', 'NA',
             'n.4555461_4555462insC', 'NA',

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
@@ -3865,7 +3865,7 @@ def test_features_comparison_kindmutations_with_dataframe(loaded_database_connec
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Total',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Total',
             'blue_count', 'red_count',
             'blue_total', 'red_total',
             'Annotation', 'Annotation_Impact',
@@ -3880,14 +3880,17 @@ def test_features_comparison_kindmutations_with_dataframe(loaded_database_connec
     assert 2 == comparison_df.loc['NC_011083:140658:C:A', 'red_count']
     assert 'hgvs_gn:NC_011083:murF:p.Ala166Glu' == comparison_df.loc[
         'NC_011083:140658:C:A', 'ID_HGVS_GN.p']
+    assert 'SNP' == comparison_df.loc['NC_011083:140658:C:A', 'Type']
     assert 1 == comparison_df.loc['NC_011083:4555461:T:TC', 'blue_count']
     assert 0 == comparison_df.loc['NC_011083:4555461:T:TC', 'red_count']
     assert 'hgvs_gn:NC_011083:n.4555461_4555462insC' == comparison_df.loc[
         'NC_011083:4555461:T:TC', 'ID_HGVS_GN.c']
+    assert 'INDEL' == comparison_df.loc['NC_011083:4555461:T:TC', 'Type']
     assert 0 == comparison_df.loc['NC_011083:630556:G:A', 'blue_count']
     assert 2 == comparison_df.loc['NC_011083:630556:G:A', 'red_count']
     assert 'hgvs_gn:NC_011083:SEHA_RS03545:p.Trp295*' == comparison_df.loc[
         'NC_011083:630556:G:A', 'ID_HGVS_GN.p']
+    assert 'SNP' == comparison_df.loc['NC_011083:630556:G:A', 'Type']
 
     # Test 2 categories counts on dataframe query: sample_query
     comparison_df = q.features_comparison(sample_categories=[category_10, category_14],
@@ -3895,7 +3898,7 @@ def test_features_comparison_kindmutations_with_dataframe(loaded_database_connec
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Total',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Total',
             '10_count', '14_count',
             '10_total', '14_total',
             'Annotation', 'Annotation_Impact',
@@ -3926,7 +3929,7 @@ def test_features_comparison_kindmutations_with_dataframe(loaded_database_connec
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Total',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Total',
             'blue_count', 'red_count',
             'blue_total', 'red_total',
             'Annotation', 'Annotation_Impact',
@@ -3957,7 +3960,7 @@ def test_features_comparison_kindmutations_with_dataframe(loaded_database_connec
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Total',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Total',
             'red_count',
             'red_total',
             'Annotation', 'Annotation_Impact',
@@ -3984,7 +3987,7 @@ def test_features_comparison_kindmutations_with_dataframe(loaded_database_connec
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Total',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Total',
             '14_count',
             '14_total',
             'Annotation', 'Annotation_Impact',
@@ -4017,7 +4020,7 @@ def test_features_comparison_kindmutations_with_dataframe(loaded_database_connec
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Total',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Total',
             'blue_count', 'green_count', 'red_count',
             'blue_total', 'green_total', 'red_total',
             'Annotation', 'Annotation_Impact',
@@ -4058,7 +4061,7 @@ def test_features_comparison_kindmutations_with_dataframe(loaded_database_connec
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Total',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Total',
             'green_count', 'red_count',
             'green_total', 'red_total',
             'Annotation', 'Annotation_Impact',

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
@@ -3259,6 +3259,7 @@ def test_summary_features_kindmutations(loaded_database_connection: DataIndexCon
         'Position': 'first',
         'Deletion': 'first',
         'Insertion': 'first',
+        'Type': 'first',
         'Mutation': 'count',
     }).rename(columns={'Mutation': 'Count'}).sort_index()
     expected_df['Total'] = 9
@@ -3276,6 +3277,7 @@ def test_summary_features_kindmutations(loaded_database_connection: DataIndexCon
     assert list(expected_df.index) == list(mutations_df.index)
     assert list(expected_df['Count']) == list(mutations_df['Count'])
     assert list(expected_df['Total']) == list(mutations_df['Total'])
+    assert list(expected_df['Type']) == list(mutations_df['Type'])
     assert math.isclose(100 * (2 / 9), mutations_df.loc['reference:619:G:C', 'Percent'])
 
     # Test including unknowns
@@ -3287,10 +3289,12 @@ def test_summary_features_kindmutations(loaded_database_connection: DataIndexCon
     assert 632 == len(mutations_df)
     assert list(expected_df.columns) == list(mutations_df.columns)
     assert 2 == mutations_df.loc['reference:619:G:C', 'Count']
+    assert 'SNP' == mutations_df.loc['reference:619:G:C', 'Type']
     assert 2 == mutations_df.loc['reference:3063:A:ATGCAGC', 'Count']
     assert 1 == mutations_df.loc['reference:1984:GTGATTG:TTGA', 'Count']
     assert 1 == mutations_df.loc['reference:866:GCCAGATCC:G', 'Count']
     assert 3 == mutations_df.loc['reference:90:T:?', 'Count']
+    assert 'UNKNOWN_MISSING' == mutations_df.loc['reference:90:T:?', 'Type']
     assert 2 == mutations_df.loc['reference:190:A:?', 'Count']
     assert 1 == mutations_df.loc['reference:887:T:?', 'Count']
 
@@ -3304,6 +3308,7 @@ def test_summary_features_kindmutations(loaded_database_connection: DataIndexCon
     assert 521 == len(mutations_df)
     assert list(expected_df.columns) == list(mutations_df.columns)
     assert 3 == mutations_df.loc['reference:90:T:?', 'Count']
+    assert 'UNKNOWN_MISSING' == mutations_df.loc['reference:90:T:?', 'Type']
     assert 2 == mutations_df.loc['reference:190:A:?', 'Count']
     assert 1 == mutations_df.loc['reference:887:T:?', 'Count']
     assert 'reference:619:G:C' not in mutations_df
@@ -3321,6 +3326,7 @@ def test_summary_features_kindmutations_unique(loaded_database_connection: DataI
         'Position': 'first',
         'Deletion': 'first',
         'Insertion': 'first',
+        'Type': 'first',
         'Mutation': 'count',
     }).rename(columns={'Mutation': 'Count'}).sort_index()
     expected_df['Total'] = 1
@@ -3340,6 +3346,7 @@ def test_summary_features_kindmutations_unique(loaded_database_connection: DataI
     assert list(expected_df.index) == list(mutations_df.index)
     assert list(expected_df['Count']) == list(mutations_df['Count'])
     assert list(expected_df['Total']) == list(mutations_df['Total'])
+    assert list(expected_df['Type']) == list(mutations_df['Type'])
     assert math.isclose(100 * (1 / 1), mutations_df.loc['reference:3656:CATT:C', 'Percent'])
 
     # Unique to B
@@ -3350,6 +3357,7 @@ def test_summary_features_kindmutations_unique(loaded_database_connection: DataI
         'Position': 'first',
         'Deletion': 'first',
         'Insertion': 'first',
+        'Type': 'first',
         'Mutation': 'count',
     }).rename(columns={'Mutation': 'Count'}).sort_index()
     expected_df['Total'] = 1
@@ -3361,6 +3369,7 @@ def test_summary_features_kindmutations_unique(loaded_database_connection: DataI
     assert len(expected_df) == len(mutations_df)
     assert list(expected_df.index) == list(mutations_df.index)
     assert list(expected_df['Count']) == list(mutations_df['Count'])
+    assert list(expected_df['Type']) == list(mutations_df['Type'])
     assert list(expected_df['Total']) == list(mutations_df['Total'])
     assert math.isclose(100 * (1 / 1), mutations_df.loc['reference:349:AAGT:A', 'Percent'])
 
@@ -3372,6 +3381,7 @@ def test_summary_features_kindmutations_unique(loaded_database_connection: DataI
         'Position': 'first',
         'Deletion': 'first',
         'Insertion': 'first',
+        'Type': 'first',
         'Mutation': 'count',
     }).rename(columns={'Mutation': 'Count'}).sort_index()
     expected_df['Total'] = 1
@@ -3384,6 +3394,7 @@ def test_summary_features_kindmutations_unique(loaded_database_connection: DataI
     assert list(expected_df.index) == list(mutations_df.index)
     assert list(expected_df['Count']) == list(mutations_df['Count'])
     assert list(expected_df['Total']) == list(mutations_df['Total'])
+    assert list(expected_df['Type']) == list(mutations_df['Type'])
     assert math.isclose(100 * (1 / 1), mutations_df.loc['reference:866:GCCAGATCC:G', 'Percent'])
 
     # Unique to BC
@@ -3394,6 +3405,7 @@ def test_summary_features_kindmutations_unique(loaded_database_connection: DataI
         'Position': 'first',
         'Deletion': 'first',
         'Insertion': 'first',
+        'Type': 'first',
         'Mutation': 'count',
     }).rename(columns={'Mutation': 'Count'}).sort_index()
     expected_df['Total'] = 2
@@ -3407,6 +3419,7 @@ def test_summary_features_kindmutations_unique(loaded_database_connection: DataI
     assert list(expected_df.index) == list(mutations_df.index)
     assert list(expected_df['Count']) == list(mutations_df['Count'])
     assert list(expected_df['Total']) == list(mutations_df['Total'])
+    assert list(expected_df['Type']) == list(mutations_df['Type'])
     assert math.isclose(100 * (2 / 2), mutations_df.loc['reference:619:G:C', 'Percent'])
     assert math.isclose(100 * (1 / 2), mutations_df.loc['reference:866:GCCAGATCC:G', 'Percent'])
     assert math.isclose(100 * (1 / 2), mutations_df.loc['reference:349:AAGT:A', 'Percent'])
@@ -3419,6 +3432,7 @@ def test_summary_features_kindmutations_unique(loaded_database_connection: DataI
         'Position': 'first',
         'Deletion': 'first',
         'Insertion': 'first',
+        'Type': 'first',
         'Mutation': 'count',
     }).rename(columns={'Mutation': 'Count'}).sort_index()
     expected_df['Total'] = 3
@@ -3436,6 +3450,7 @@ def test_summary_features_kindmutations_unique(loaded_database_connection: DataI
     assert 111 == len(mutations_df)  # Check length against independently generated length
     assert list(expected_df.index) == list(mutations_df.index)
     assert list(expected_df['Count']) == list(mutations_df['Count'])
+    assert list(expected_df['Type']) == list(mutations_df['Type'])
     assert list(expected_df['Total']) == list(mutations_df['Total'])
     assert math.isclose(100 * (2 / 3), mutations_df.loc['reference:619:G:C', 'Percent'])
     assert math.isclose(100 * (1 / 3), mutations_df.loc['reference:866:GCCAGATCC:G', 'Percent'])
@@ -3447,7 +3462,7 @@ def test_summary_features_kindmutations_unique(loaded_database_connection: DataI
     mutations_df = mutations_df.sort_index()
 
     assert 0 == len(mutations_df)
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Count', 'Total', 'Percent'] == list(mutations_df.columns)
 
 
@@ -3457,7 +3472,7 @@ def test_summary_features_kindmutations_annotations(loaded_database_connection_a
     # 1 sample
     mutations_df = q.isa('SH10-014').features_summary(ignore_annotations=False)
 
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Count', 'Total', 'Percent', 'Annotation', 'Annotation_Impact',
             'Gene_Name', 'Gene_ID', 'Feature_Type', 'Transcript_BioType',
             'HGVS.c', 'HGVS.p', 'ID_HGVS.c', 'ID_HGVS.p', 'ID_HGVS_GN.c', 'ID_HGVS_GN.p'] == list(mutations_df.columns)
@@ -3467,7 +3482,7 @@ def test_summary_features_kindmutations_annotations(loaded_database_connection_a
     mutations_df['Percent'] = mutations_df['Percent'].astype(int)
 
     ## missense variant
-    assert ['NC_011083', 140658, 'C', 'A', 1, 1, 100,
+    assert ['NC_011083', 140658, 'C', 'A', 'SNP', 1, 1, 100,
             'missense_variant', 'MODERATE', 'murF', 'SEHA_RS01180', 'transcript', 'protein_coding',
             'c.497C>A', 'p.Ala166Glu',
             'hgvs:NC_011083:SEHA_RS01180:c.497C>A', 'hgvs:NC_011083:SEHA_RS01180:p.Ala166Glu',
@@ -3475,7 +3490,7 @@ def test_summary_features_kindmutations_annotations(loaded_database_connection_a
         mutations_df.loc['NC_011083:140658:C:A'])
 
     ## inframe deletion
-    assert ['NC_011083', 4465400, 'GGCCGAA', 'G', 1, 1, 100,
+    assert ['NC_011083', 4465400, 'GGCCGAA', 'G', 'INDEL', 1, 1, 100,
             'conservative_inframe_deletion', 'MODERATE', 'tyrB', 'SEHA_RS22180', 'transcript', 'protein_coding',
             'c.157_162delGAAGCC', 'p.Glu53_Ala54del',
             'hgvs:NC_011083:SEHA_RS22180:c.157_162delGAAGCC', 'hgvs:NC_011083:SEHA_RS22180:p.Glu53_Ala54del',
@@ -3483,7 +3498,7 @@ def test_summary_features_kindmutations_annotations(loaded_database_connection_a
         mutations_df.loc['NC_011083:4465400:GGCCGAA:G'])
 
     ## Intergenic variant (with some NA values in fields)
-    assert ['NC_011083', 4555461, 'T', 'TC', 1, 1, 100,
+    assert ['NC_011083', 4555461, 'T', 'TC', 'INDEL', 1, 1, 100,
             'intergenic_region', 'MODIFIER', 'SEHA_RS22510-SEHA_RS26685', 'SEHA_RS22510-SEHA_RS26685',
             'intergenic_region', 'NA',
             'n.4555461_4555462insC', 'NA',
@@ -3497,14 +3512,14 @@ def test_summary_features_kindmutations_annotations(loaded_database_connection_a
     ## Convert percent to int to make it easier to compare in assert statements
     mutations_df['Percent'] = mutations_df['Percent'].astype(int)
 
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Count', 'Total', 'Percent', 'Annotation', 'Annotation_Impact',
             'Gene_Name', 'Gene_ID', 'Feature_Type', 'Transcript_BioType',
             'HGVS.c', 'HGVS.p', 'ID_HGVS.c', 'ID_HGVS.p', 'ID_HGVS_GN.c', 'ID_HGVS_GN.p'] == list(mutations_df.columns)
     assert 177 == len(mutations_df)
 
     ## missense variant (3/3)
-    assert ['NC_011083', 140658, 'C', 'A', 3, 3, 100,
+    assert ['NC_011083', 140658, 'C', 'A', 'SNP', 3, 3, 100,
             'missense_variant', 'MODERATE', 'murF', 'SEHA_RS01180', 'transcript', 'protein_coding',
             'c.497C>A', 'p.Ala166Glu',
             'hgvs:NC_011083:SEHA_RS01180:c.497C>A', 'hgvs:NC_011083:SEHA_RS01180:p.Ala166Glu',
@@ -3512,7 +3527,7 @@ def test_summary_features_kindmutations_annotations(loaded_database_connection_a
         mutations_df.loc['NC_011083:140658:C:A'])
 
     ## Intergenic variant (1/3)
-    assert ['NC_011083', 4555461, 'T', 'TC', 1, 3, 33,
+    assert ['NC_011083', 4555461, 'T', 'TC', 'INDEL', 1, 3, 33,
             'intergenic_region', 'MODIFIER', 'SEHA_RS22510-SEHA_RS26685', 'SEHA_RS22510-SEHA_RS26685',
             'intergenic_region', 'NA',
             'n.4555461_4555462insC', 'NA',
@@ -3523,7 +3538,7 @@ def test_summary_features_kindmutations_annotations(loaded_database_connection_a
     # Test ignore annotations
     mutations_df = q.isin(['SH10-014', 'SH14-001', 'SH14-014']).features_summary(ignore_annotations=True)
 
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Count', 'Total', 'Percent'] == list(mutations_df.columns)
     assert 177 == len(mutations_df)
 
@@ -3533,14 +3548,14 @@ def test_summary_features_kindmutations_annotations(loaded_database_connection_a
     ## Convert percent to int to make it easier to compare in assert statements
     mutations_df['Percent'] = mutations_df['Percent'].astype(int)
 
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Count', 'Total', 'Percent', 'Annotation', 'Annotation_Impact',
             'Gene_Name', 'Gene_ID', 'Feature_Type', 'Transcript_BioType',
             'HGVS.c', 'HGVS.p', 'ID_HGVS.c', 'ID_HGVS.p', 'ID_HGVS_GN.c', 'ID_HGVS_GN.p'] == list(mutations_df.columns)
     assert 60 == len(mutations_df)
 
     ## missense variant
-    assert ['NC_011083', 2049576, 'A', 'C', 1, 1, 100,
+    assert ['NC_011083', 2049576, 'A', 'C', 'SNP', 1, 1, 100,
             'missense_variant', 'MODERATE', 'cutC', 'SEHA_RS10675', 'transcript', 'protein_coding',
             'c.536T>G', 'p.Val179Gly',
             'hgvs:NC_011083:SEHA_RS10675:c.536T>G', 'hgvs:NC_011083:SEHA_RS10675:p.Val179Gly',
@@ -3557,6 +3572,7 @@ def test_summary_features_two(loaded_database_connection: DataIndexConnection):
         'Position': 'first',
         'Deletion': 'first',
         'Insertion': 'first',
+        'Type': 'first',
         'Mutation': 'count',
     }).rename(columns={'Mutation': 'Count'}).sort_index()
     expected_df['Total'] = 2
@@ -3569,6 +3585,7 @@ def test_summary_features_two(loaded_database_connection: DataIndexConnection):
     assert len(expected_df) == len(mutations_df)
     assert list(expected_df.index) == list(mutations_df.index)
     assert list(expected_df['Count']) == list(mutations_df['Count'])
+    assert list(expected_df['Type']) == list(mutations_df['Type'])
     assert list(expected_df['Total']) == list(mutations_df['Total'])
     assert math.isclose(100 * (2 / 2), mutations_df.loc['reference:839:C:G', 'Percent'])
 
@@ -3638,7 +3655,7 @@ def test_features_comparison_kindmutations_annotations(loaded_database_connectio
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Total',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Total',
             '10_count', '14_count',
             '10_total', '14_total',
             'Annotation', 'Annotation_Impact',
@@ -3650,6 +3667,7 @@ def test_features_comparison_kindmutations_annotations(loaded_database_connectio
     assert {1} == set(comparison_df['10_total'].tolist())
     assert {2} == set(comparison_df['14_total'].tolist())
     assert 1 == comparison_df.loc['NC_011083:140658:C:A', '10_count']
+    assert 'SNP' == comparison_df.loc['NC_011083:140658:C:A', 'Type']
     assert 2 == comparison_df.loc['NC_011083:140658:C:A', '14_count']
     assert 'hgvs_gn:NC_011083:murF:p.Ala166Glu' == comparison_df.loc[
         'NC_011083:140658:C:A', 'ID_HGVS_GN.p']
@@ -3670,7 +3688,7 @@ def test_features_comparison_kindmutations_annotations(loaded_database_connectio
     comparison_df['Category2_percent'] = comparison_df['Category2_percent'].astype(
         int)  # Convert to int for easier comparison
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Total',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Total',
             'Category1_percent', 'Category2_percent',
             'Category1_total', 'Category2_total',
             'Annotation', 'Annotation_Impact',
@@ -3703,7 +3721,7 @@ def test_features_comparison_kindmutations_annotations(loaded_database_connectio
     comparison_df = comparison_df.sort_index()
     comparison_df['14_percent'] = comparison_df['14_percent'].astype(int)  # Convert to int for easier comparison
     assert comparison_df.index.name == 'Mutation'
-    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Total',
+    assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type', 'Total',
             '10_percent', '14_percent',
             '10_total', '14_total',
             'Annotation', 'Annotation_Impact',

--- a/genomics_data_index/test/integration/data/snippy/README.md
+++ b/genomics_data_index/test/integration/data/snippy/README.md
@@ -10,13 +10,13 @@ bcftools index snps.fill-tags.vcf.gz
 Generated `Sample*/mutations-dataframe.snps.tsv` with:
 
 ```
-echo -e "Mutation\tSequence\tPosition\tDeletion\tInsertion" > mutations-dataframe.snps.tsv
-zgrep -v '^#' snps.fill-tags.vcf.gz | grep SNP | cut -f 1,2,4,5 | tr '\t' ':' | perl -ne 'chomp;@a=split(/:/, $_);print($_, "\t", $a[0], "\t", $a[1], "\t", $a[2], "\t", $a[3], "\n");' >> mutations-dataframe.snps.tsv
+echo -e "Mutation\tSequence\tPosition\tDeletion\tInsertion\tType" > mutations-dataframe.snps.tsv
+zgrep -v '^#' snps.fill-tags.vcf.gz | cut -f 1,2,4,5,8 | sed -e 's/[^\t]*TYPE=\(.*\)$/\1/' | perl -ne 'chomp;@a=split(/\t/, $_);print("$a[0]:$a[1]:$a[2]:$a[3]", "\t", $a[0], "\t", $a[1], "\t", $a[2], "\t", $a[3], "\t", $a[4], "\n");' | grep SNP >> mutations-dataframe.snps.tsv
 ```
 
 Generated `Sample*/mutations-dataframe.all.tsv` with:
 
 ```
-echo -e "Mutation\tSequence\tPosition\tDeletion\tInsertion" > mutations-dataframe.all.tsv
-zgrep -v '^#' snps.fill-tags.vcf.gz | cut -f 1,2,4,5 | tr '\t' ':' | perl -ne 'chomp;@a=split(/:/, $_);print($_, "\t", $a[0], "\t", $a[1], "\t", $a[2], "\t", $a[3], "\n");' >> mutations-dataframe.all.tsv
+echo -e "Mutation\tSequence\tPosition\tDeletion\tInsertion\tType" > mutations-dataframe.all.tsv
+zgrep -v '^#' snps.fill-tags.vcf.gz | cut -f 1,2,4,5,8 | sed -e 's/[^\t]*TYPE=\(.*\)$/\1/' | perl -ne 'chomp;@a=split(/\t/, $_);print("$a[0]:$a[1]:$a[2]:$a[3]", "\t", $a[0], "\t", $a[1], "\t", $a[2], "\t", $a[3], "\t", $a[4], "\n");' >> mutations-dataframe.all.tsv
 ```

--- a/genomics_data_index/test/integration/data/snippy/SampleA/mutations-dataframe.all.tsv
+++ b/genomics_data_index/test/integration/data/snippy/SampleA/mutations-dataframe.all.tsv
@@ -1,47 +1,47 @@
-Mutation	Sequence	Position	Deletion	Insertion
-reference:293:C:T	reference	293	C	T
-reference:302:CT:C	reference	302	CT	C
-reference:324:C:CAA	reference	324	C	CAA
-reference:374:A:ATTCTAGGGTAGACGCT	reference	374	A	ATTCTAGGGTAGACGCT
-reference:461:AAAT:G	reference	461	AAAT	G
-reference:506:G:C	reference	506	G	C
-reference:641:A:G	reference	641	A	G
-reference:674:A:T	reference	674	A	T
-reference:744:A:G	reference	744	A	G
-reference:1048:C:G	reference	1048	C	G
-reference:1120:G:C	reference	1120	G	C
-reference:1130:T:TA	reference	1130	T	TA
-reference:1167:GA:G	reference	1167	GA	G
-reference:1209:AG:A	reference	1209	AG	A
-reference:1223:G:C	reference	1223	G	C
-reference:1253:T:TAA	reference	1253	T	TAA
-reference:1330:G:T	reference	1330	G	T
-reference:1368:C:A	reference	1368	C	A
-reference:1413:C:CT	reference	1413	C	CT
-reference:1616:T:TG	reference	1616	T	TG
-reference:1684:A:C	reference	1684	A	C
-reference:1708:ATGCTGTTCAATAC:A	reference	1708	ATGCTGTTCAATAC	A
-reference:1825:G:C	reference	1825	G	C
-reference:1938:G:GT	reference	1938	G	GT
-reference:2030:C:G	reference	2030	C	G
-reference:2057:T:A	reference	2057	T	A
-reference:2076:A:T	reference	2076	A	T
-reference:2233:T:TCG	reference	2233	T	TCG
-reference:2243:T:TG	reference	2243	T	TG
-reference:2419:GA:G	reference	2419	GA	G
-reference:2435:T:A	reference	2435	T	A
-reference:2552:A:G	reference	2552	A	G
-reference:2583:C:T	reference	2583	C	T
-reference:2858:T:TG	reference	2858	T	TG
-reference:2876:C:CT	reference	2876	C	CT
-reference:2887:C:A	reference	2887	C	A
-reference:2953:A:T	reference	2953	A	T
-reference:3258:T:TA	reference	3258	T	TA
-reference:3326:G:C	reference	3326	G	C
-reference:3656:CATT:C	reference	3656	CATT	C
-reference:4265:G:C	reference	4265	G	C
-reference:4382:A:C	reference	4382	A	C
-reference:4437:AG:A	reference	4437	AG	A
-reference:4562:G:A	reference	4562	G	A
-reference:4588:C:A	reference	4588	C	A
-reference:4929:C:G	reference	4929	C	G
+Mutation	Sequence	Position	Deletion	Insertion	Type
+reference:293:C:T	reference	293	C	T	SNP
+reference:302:CT:C	reference	302	CT	C	INDEL
+reference:324:C:CAA	reference	324	C	CAA	INDEL
+reference:374:A:ATTCTAGGGTAGACGCT	reference	374	A	ATTCTAGGGTAGACGCT	INDEL
+reference:461:AAAT:G	reference	461	AAAT	G	OTHER
+reference:506:G:C	reference	506	G	C	SNP
+reference:641:A:G	reference	641	A	G	SNP
+reference:674:A:T	reference	674	A	T	SNP
+reference:744:A:G	reference	744	A	G	SNP
+reference:1048:C:G	reference	1048	C	G	SNP
+reference:1120:G:C	reference	1120	G	C	SNP
+reference:1130:T:TA	reference	1130	T	TA	INDEL
+reference:1167:GA:G	reference	1167	GA	G	INDEL
+reference:1209:AG:A	reference	1209	AG	A	INDEL
+reference:1223:G:C	reference	1223	G	C	SNP
+reference:1253:T:TAA	reference	1253	T	TAA	INDEL
+reference:1330:G:T	reference	1330	G	T	SNP
+reference:1368:C:A	reference	1368	C	A	SNP
+reference:1413:C:CT	reference	1413	C	CT	INDEL
+reference:1616:T:TG	reference	1616	T	TG	INDEL
+reference:1684:A:C	reference	1684	A	C	SNP
+reference:1708:ATGCTGTTCAATAC:A	reference	1708	ATGCTGTTCAATAC	A	INDEL
+reference:1825:G:C	reference	1825	G	C	SNP
+reference:1938:G:GT	reference	1938	G	GT	INDEL
+reference:2030:C:G	reference	2030	C	G	SNP
+reference:2057:T:A	reference	2057	T	A	SNP
+reference:2076:A:T	reference	2076	A	T	SNP
+reference:2233:T:TCG	reference	2233	T	TCG	INDEL
+reference:2243:T:TG	reference	2243	T	TG	INDEL
+reference:2419:GA:G	reference	2419	GA	G	INDEL
+reference:2435:T:A	reference	2435	T	A	SNP
+reference:2552:A:G	reference	2552	A	G	SNP
+reference:2583:C:T	reference	2583	C	T	SNP
+reference:2858:T:TG	reference	2858	T	TG	INDEL
+reference:2876:C:CT	reference	2876	C	CT	INDEL
+reference:2887:C:A	reference	2887	C	A	SNP
+reference:2953:A:T	reference	2953	A	T	SNP
+reference:3258:T:TA	reference	3258	T	TA	INDEL
+reference:3326:G:C	reference	3326	G	C	SNP
+reference:3656:CATT:C	reference	3656	CATT	C	INDEL
+reference:4265:G:C	reference	4265	G	C	SNP
+reference:4382:A:C	reference	4382	A	C	SNP
+reference:4437:AG:A	reference	4437	AG	A	INDEL
+reference:4562:G:A	reference	4562	G	A	SNP
+reference:4588:C:A	reference	4588	C	A	SNP
+reference:4929:C:G	reference	4929	C	G	SNP

--- a/genomics_data_index/test/integration/data/snippy/SampleA/mutations-dataframe.snps.tsv
+++ b/genomics_data_index/test/integration/data/snippy/SampleA/mutations-dataframe.snps.tsv
@@ -1,27 +1,27 @@
-Mutation	Sequence	Position	Deletion	Insertion
-reference:293:C:T	reference	293	C	T
-reference:506:G:C	reference	506	G	C
-reference:641:A:G	reference	641	A	G
-reference:674:A:T	reference	674	A	T
-reference:744:A:G	reference	744	A	G
-reference:1048:C:G	reference	1048	C	G
-reference:1120:G:C	reference	1120	G	C
-reference:1223:G:C	reference	1223	G	C
-reference:1330:G:T	reference	1330	G	T
-reference:1368:C:A	reference	1368	C	A
-reference:1684:A:C	reference	1684	A	C
-reference:1825:G:C	reference	1825	G	C
-reference:2030:C:G	reference	2030	C	G
-reference:2057:T:A	reference	2057	T	A
-reference:2076:A:T	reference	2076	A	T
-reference:2435:T:A	reference	2435	T	A
-reference:2552:A:G	reference	2552	A	G
-reference:2583:C:T	reference	2583	C	T
-reference:2887:C:A	reference	2887	C	A
-reference:2953:A:T	reference	2953	A	T
-reference:3326:G:C	reference	3326	G	C
-reference:4265:G:C	reference	4265	G	C
-reference:4382:A:C	reference	4382	A	C
-reference:4562:G:A	reference	4562	G	A
-reference:4588:C:A	reference	4588	C	A
-reference:4929:C:G	reference	4929	C	G
+Mutation	Sequence	Position	Deletion	Insertion	Type
+reference:293:C:T	reference	293	C	T	SNP
+reference:506:G:C	reference	506	G	C	SNP
+reference:641:A:G	reference	641	A	G	SNP
+reference:674:A:T	reference	674	A	T	SNP
+reference:744:A:G	reference	744	A	G	SNP
+reference:1048:C:G	reference	1048	C	G	SNP
+reference:1120:G:C	reference	1120	G	C	SNP
+reference:1223:G:C	reference	1223	G	C	SNP
+reference:1330:G:T	reference	1330	G	T	SNP
+reference:1368:C:A	reference	1368	C	A	SNP
+reference:1684:A:C	reference	1684	A	C	SNP
+reference:1825:G:C	reference	1825	G	C	SNP
+reference:2030:C:G	reference	2030	C	G	SNP
+reference:2057:T:A	reference	2057	T	A	SNP
+reference:2076:A:T	reference	2076	A	T	SNP
+reference:2435:T:A	reference	2435	T	A	SNP
+reference:2552:A:G	reference	2552	A	G	SNP
+reference:2583:C:T	reference	2583	C	T	SNP
+reference:2887:C:A	reference	2887	C	A	SNP
+reference:2953:A:T	reference	2953	A	T	SNP
+reference:3326:G:C	reference	3326	G	C	SNP
+reference:4265:G:C	reference	4265	G	C	SNP
+reference:4382:A:C	reference	4382	A	C	SNP
+reference:4562:G:A	reference	4562	G	A	SNP
+reference:4588:C:A	reference	4588	C	A	SNP
+reference:4929:C:G	reference	4929	C	G	SNP

--- a/genomics_data_index/test/integration/data/snippy/SampleB/mutations-dataframe.all.tsv
+++ b/genomics_data_index/test/integration/data/snippy/SampleB/mutations-dataframe.all.tsv
@@ -1,51 +1,51 @@
-Mutation	Sequence	Position	Deletion	Insertion
-reference:190:A:G	reference	190	A	G
-reference:349:AAGT:A	reference	349	AAGT	A
-reference:488:T:G	reference	488	T	G
-reference:514:G:C	reference	514	G	C
-reference:528:C:CAG	reference	528	C	CAG
-reference:619:G:C	reference	619	G	C
-reference:839:C:G	reference	839	C	G
-reference:883:CACATG:C	reference	883	CACATG	C
-reference:1070:TG:T	reference	1070	TG	T
-reference:1135:CCT:C	reference	1135	CCT	C
-reference:1184:A:G	reference	1184	A	G
-reference:1258:G:GGGGA	reference	1258	G	GGGGA
-reference:1270:CTT:C	reference	1270	CTT	C
-reference:1304:C:T	reference	1304	C	T
-reference:1325:G:TGA	reference	1325	G	TGA
-reference:1392:C:T	reference	1392	C	T
-reference:1440:G:GCCAC	reference	1440	G	GCCAC
-reference:1483:AAAGAGGGGCTGCTGGAGCCG:A	reference	1483	AAAGAGGGGCTGCTGGAGCCG	A
-reference:1640:C:A	reference	1640	C	A
-reference:2002:T:TAG	reference	2002	T	TAG
-reference:2016:G:A	reference	2016	G	A
-reference:2083:A:T	reference	2083	A	T
-reference:2140:A:T	reference	2140	A	T
-reference:2199:C:CTT	reference	2199	C	CTT
-reference:2227:A:AG	reference	2227	A	AG
-reference:2480:TG:T	reference	2480	TG	T
-reference:2785:A:C	reference	2785	A	C
-reference:2926:C:CG	reference	2926	C	CG
-reference:3047:G:GTGCGCT	reference	3047	G	GTGCGCT
-reference:3063:A:ATGCAGC	reference	3063	A	ATGCAGC
-reference:3136:G:C	reference	3136	G	C
-reference:3263:A:G	reference	3263	A	G
-reference:3276:GC:G	reference	3276	GC	G
-reference:3513:T:G	reference	3513	T	G
-reference:3522:G:A	reference	3522	G	A
-reference:3576:TTTC:T	reference	3576	TTTC	T
-reference:3642:A:G	reference	3642	A	G
-reference:3676:A:C	reference	3676	A	C
-reference:3693:G:GC	reference	3693	G	GC
-reference:3709:G:T	reference	3709	G	T
-reference:3846:T:A	reference	3846	T	A
-reference:3897:GCGCA:G	reference	3897	GCGCA	G
-reference:4245:G:A	reference	4245	G	A
-reference:4491:T:C	reference	4491	T	C
-reference:4539:T:A	reference	4539	T	A
-reference:4585:T:C	reference	4585	T	C
-reference:4693:C:CGA	reference	4693	C	CGA
-reference:4750:G:GA	reference	4750	G	GA
-reference:4975:T:C	reference	4975	T	C
-reference:5061:G:A	reference	5061	G	A
+Mutation	Sequence	Position	Deletion	Insertion	Type
+reference:190:A:G	reference	190	A	G	SNP
+reference:349:AAGT:A	reference	349	AAGT	A	INDEL
+reference:488:T:G	reference	488	T	G	SNP
+reference:514:G:C	reference	514	G	C	SNP
+reference:528:C:CAG	reference	528	C	CAG	INDEL
+reference:619:G:C	reference	619	G	C	SNP
+reference:839:C:G	reference	839	C	G	SNP
+reference:883:CACATG:C	reference	883	CACATG	C	INDEL
+reference:1070:TG:T	reference	1070	TG	T	INDEL
+reference:1135:CCT:C	reference	1135	CCT	C	INDEL
+reference:1184:A:G	reference	1184	A	G	SNP
+reference:1258:G:GGGGA	reference	1258	G	GGGGA	INDEL
+reference:1270:CTT:C	reference	1270	CTT	C	INDEL
+reference:1304:C:T	reference	1304	C	T	SNP
+reference:1325:G:TGA	reference	1325	G	TGA	OTHER
+reference:1392:C:T	reference	1392	C	T	SNP
+reference:1440:G:GCCAC	reference	1440	G	GCCAC	INDEL
+reference:1483:AAAGAGGGGCTGCTGGAGCCG:A	reference	1483	AAAGAGGGGCTGCTGGAGCCG	A	INDEL
+reference:1640:C:A	reference	1640	C	A	SNP
+reference:2002:T:TAG	reference	2002	T	TAG	INDEL
+reference:2016:G:A	reference	2016	G	A	SNP
+reference:2083:A:T	reference	2083	A	T	SNP
+reference:2140:A:T	reference	2140	A	T	SNP
+reference:2199:C:CTT	reference	2199	C	CTT	INDEL
+reference:2227:A:AG	reference	2227	A	AG	INDEL
+reference:2480:TG:T	reference	2480	TG	T	INDEL
+reference:2785:A:C	reference	2785	A	C	SNP
+reference:2926:C:CG	reference	2926	C	CG	INDEL
+reference:3047:G:GTGCGCT	reference	3047	G	GTGCGCT	INDEL
+reference:3063:A:ATGCAGC	reference	3063	A	ATGCAGC	INDEL
+reference:3136:G:C	reference	3136	G	C	SNP
+reference:3263:A:G	reference	3263	A	G	SNP
+reference:3276:GC:G	reference	3276	GC	G	INDEL
+reference:3513:T:G	reference	3513	T	G	SNP
+reference:3522:G:A	reference	3522	G	A	SNP
+reference:3576:TTTC:T	reference	3576	TTTC	T	INDEL
+reference:3642:A:G	reference	3642	A	G	SNP
+reference:3676:A:C	reference	3676	A	C	SNP
+reference:3693:G:GC	reference	3693	G	GC	INDEL
+reference:3709:G:T	reference	3709	G	T	SNP
+reference:3846:T:A	reference	3846	T	A	SNP
+reference:3897:GCGCA:G	reference	3897	GCGCA	G	INDEL
+reference:4245:G:A	reference	4245	G	A	SNP
+reference:4491:T:C	reference	4491	T	C	SNP
+reference:4539:T:A	reference	4539	T	A	SNP
+reference:4585:T:C	reference	4585	T	C	SNP
+reference:4693:C:CGA	reference	4693	C	CGA	INDEL
+reference:4750:G:GA	reference	4750	G	GA	INDEL
+reference:4975:T:C	reference	4975	T	C	SNP
+reference:5061:G:A	reference	5061	G	A	SNP

--- a/genomics_data_index/test/integration/data/snippy/SampleB/mutations-dataframe.snps.tsv
+++ b/genomics_data_index/test/integration/data/snippy/SampleB/mutations-dataframe.snps.tsv
@@ -1,28 +1,28 @@
-Mutation	Sequence	Position	Deletion	Insertion
-reference:190:A:G	reference	190	A	G
-reference:488:T:G	reference	488	T	G
-reference:514:G:C	reference	514	G	C
-reference:619:G:C	reference	619	G	C
-reference:839:C:G	reference	839	C	G
-reference:1184:A:G	reference	1184	A	G
-reference:1304:C:T	reference	1304	C	T
-reference:1392:C:T	reference	1392	C	T
-reference:1640:C:A	reference	1640	C	A
-reference:2016:G:A	reference	2016	G	A
-reference:2083:A:T	reference	2083	A	T
-reference:2140:A:T	reference	2140	A	T
-reference:2785:A:C	reference	2785	A	C
-reference:3136:G:C	reference	3136	G	C
-reference:3263:A:G	reference	3263	A	G
-reference:3513:T:G	reference	3513	T	G
-reference:3522:G:A	reference	3522	G	A
-reference:3642:A:G	reference	3642	A	G
-reference:3676:A:C	reference	3676	A	C
-reference:3709:G:T	reference	3709	G	T
-reference:3846:T:A	reference	3846	T	A
-reference:4245:G:A	reference	4245	G	A
-reference:4491:T:C	reference	4491	T	C
-reference:4539:T:A	reference	4539	T	A
-reference:4585:T:C	reference	4585	T	C
-reference:4975:T:C	reference	4975	T	C
-reference:5061:G:A	reference	5061	G	A
+Mutation	Sequence	Position	Deletion	Insertion	Type
+reference:190:A:G	reference	190	A	G	SNP
+reference:488:T:G	reference	488	T	G	SNP
+reference:514:G:C	reference	514	G	C	SNP
+reference:619:G:C	reference	619	G	C	SNP
+reference:839:C:G	reference	839	C	G	SNP
+reference:1184:A:G	reference	1184	A	G	SNP
+reference:1304:C:T	reference	1304	C	T	SNP
+reference:1392:C:T	reference	1392	C	T	SNP
+reference:1640:C:A	reference	1640	C	A	SNP
+reference:2016:G:A	reference	2016	G	A	SNP
+reference:2083:A:T	reference	2083	A	T	SNP
+reference:2140:A:T	reference	2140	A	T	SNP
+reference:2785:A:C	reference	2785	A	C	SNP
+reference:3136:G:C	reference	3136	G	C	SNP
+reference:3263:A:G	reference	3263	A	G	SNP
+reference:3513:T:G	reference	3513	T	G	SNP
+reference:3522:G:A	reference	3522	G	A	SNP
+reference:3642:A:G	reference	3642	A	G	SNP
+reference:3676:A:C	reference	3676	A	C	SNP
+reference:3709:G:T	reference	3709	G	T	SNP
+reference:3846:T:A	reference	3846	T	A	SNP
+reference:4245:G:A	reference	4245	G	A	SNP
+reference:4491:T:C	reference	4491	T	C	SNP
+reference:4539:T:A	reference	4539	T	A	SNP
+reference:4585:T:C	reference	4585	T	C	SNP
+reference:4975:T:C	reference	4975	T	C	SNP
+reference:5061:G:A	reference	5061	G	A	SNP

--- a/genomics_data_index/test/integration/data/snippy/SampleC/mutations-dataframe.all.tsv
+++ b/genomics_data_index/test/integration/data/snippy/SampleC/mutations-dataframe.all.tsv
@@ -1,34 +1,34 @@
-Mutation	Sequence	Position	Deletion	Insertion
-reference:347:TGAAG:T	reference	347	TGAAG	T
-reference:619:G:C	reference	619	G	C
-reference:839:C:G	reference	839	C	G
-reference:866:GCCAGATCC:G	reference	866	GCCAGATCC	G
-reference:1056:G:GC	reference	1056	G	GC
-reference:1135:CCT:C	reference	1135	CCT	C
-reference:1184:A:G	reference	1184	A	G
-reference:1270:CTT:C	reference	1270	CTT	C
-reference:1347:C:A	reference	1347	C	A
-reference:1440:G:GCCAC	reference	1440	G	GCCAC
-reference:1815:CAA:C	reference	1815	CAA	C
-reference:1984:GTGATTG:TTGA	reference	1984	GTGATTG	TTGA
-reference:2480:TG:T	reference	2480	TG	T
-reference:2539:A:AG	reference	2539	A	AG
-reference:3008:GA:G	reference	3008	GA	G
-reference:3063:A:ATGCAGC	reference	3063	A	ATGCAGC
-reference:3263:A:G	reference	3263	A	G
-reference:3337:C:G	reference	3337	C	G
-reference:3522:G:A	reference	3522	G	A
-reference:3526:T:TA	reference	3526	T	TA
-reference:3642:A:G	reference	3642	A	G
-reference:3733:A:AAATC	reference	3733	A	AAATC
-reference:3762:A:G	reference	3762	A	G
-reference:3846:T:A	reference	3846	T	A
-reference:3897:GCGCA:G	reference	3897	GCGCA	G
-reference:4036:T:A	reference	4036	T	A
-reference:4245:G:A	reference	4245	G	A
-reference:4585:T:C	reference	4585	T	C
-reference:4628:A:G	reference	4628	A	G
-reference:4644:G:A	reference	4644	G	A
-reference:4693:C:CGA	reference	4693	C	CGA
-reference:4765:A:G	reference	4765	A	G
-reference:4975:T:C	reference	4975	T	C
+Mutation	Sequence	Position	Deletion	Insertion	Type
+reference:347:TGAAG:T	reference	347	TGAAG	T	INDEL
+reference:619:G:C	reference	619	G	C	SNP
+reference:839:C:G	reference	839	C	G	SNP
+reference:866:GCCAGATCC:G	reference	866	GCCAGATCC	G	INDEL
+reference:1056:G:GC	reference	1056	G	GC	INDEL
+reference:1135:CCT:C	reference	1135	CCT	C	INDEL
+reference:1184:A:G	reference	1184	A	G	SNP
+reference:1270:CTT:C	reference	1270	CTT	C	INDEL
+reference:1347:C:A	reference	1347	C	A	SNP
+reference:1440:G:GCCAC	reference	1440	G	GCCAC	INDEL
+reference:1815:CAA:C	reference	1815	CAA	C	INDEL
+reference:1984:GTGATTG:TTGA	reference	1984	GTGATTG	TTGA	OTHER
+reference:2480:TG:T	reference	2480	TG	T	INDEL
+reference:2539:A:AG	reference	2539	A	AG	INDEL
+reference:3008:GA:G	reference	3008	GA	G	INDEL
+reference:3063:A:ATGCAGC	reference	3063	A	ATGCAGC	INDEL
+reference:3263:A:G	reference	3263	A	G	SNP
+reference:3337:C:G	reference	3337	C	G	SNP
+reference:3522:G:A	reference	3522	G	A	SNP
+reference:3526:T:TA	reference	3526	T	TA	INDEL
+reference:3642:A:G	reference	3642	A	G	SNP
+reference:3733:A:AAATC	reference	3733	A	AAATC	INDEL
+reference:3762:A:G	reference	3762	A	G	SNP
+reference:3846:T:A	reference	3846	T	A	SNP
+reference:3897:GCGCA:G	reference	3897	GCGCA	G	INDEL
+reference:4036:T:A	reference	4036	T	A	SNP
+reference:4245:G:A	reference	4245	G	A	SNP
+reference:4585:T:C	reference	4585	T	C	SNP
+reference:4628:A:G	reference	4628	A	G	SNP
+reference:4644:G:A	reference	4644	G	A	SNP
+reference:4693:C:CGA	reference	4693	C	CGA	INDEL
+reference:4765:A:G	reference	4765	A	G	SNP
+reference:4975:T:C	reference	4975	T	C	SNP

--- a/genomics_data_index/test/integration/data/snippy/SampleC/mutations-dataframe.snps.tsv
+++ b/genomics_data_index/test/integration/data/snippy/SampleC/mutations-dataframe.snps.tsv
@@ -1,18 +1,18 @@
-Mutation	Sequence	Position	Deletion	Insertion
-reference:619:G:C	reference	619	G	C
-reference:839:C:G	reference	839	C	G
-reference:1184:A:G	reference	1184	A	G
-reference:1347:C:A	reference	1347	C	A
-reference:3263:A:G	reference	3263	A	G
-reference:3337:C:G	reference	3337	C	G
-reference:3522:G:A	reference	3522	G	A
-reference:3642:A:G	reference	3642	A	G
-reference:3762:A:G	reference	3762	A	G
-reference:3846:T:A	reference	3846	T	A
-reference:4036:T:A	reference	4036	T	A
-reference:4245:G:A	reference	4245	G	A
-reference:4585:T:C	reference	4585	T	C
-reference:4628:A:G	reference	4628	A	G
-reference:4644:G:A	reference	4644	G	A
-reference:4765:A:G	reference	4765	A	G
-reference:4975:T:C	reference	4975	T	C
+Mutation	Sequence	Position	Deletion	Insertion	Type
+reference:619:G:C	reference	619	G	C	SNP
+reference:839:C:G	reference	839	C	G	SNP
+reference:1184:A:G	reference	1184	A	G	SNP
+reference:1347:C:A	reference	1347	C	A	SNP
+reference:3263:A:G	reference	3263	A	G	SNP
+reference:3337:C:G	reference	3337	C	G	SNP
+reference:3522:G:A	reference	3522	G	A	SNP
+reference:3642:A:G	reference	3642	A	G	SNP
+reference:3762:A:G	reference	3762	A	G	SNP
+reference:3846:T:A	reference	3846	T	A	SNP
+reference:4036:T:A	reference	4036	T	A	SNP
+reference:4245:G:A	reference	4245	G	A	SNP
+reference:4585:T:C	reference	4585	T	C	SNP
+reference:4628:A:G	reference	4628	A	G	SNP
+reference:4644:G:A	reference	4644	G	A	SNP
+reference:4765:A:G	reference	4765	A	G	SNP
+reference:4975:T:C	reference	4975	T	C	SNP

--- a/genomics_data_index/test/integration/storage/service/test_CoreAlignmentService.py
+++ b/genomics_data_index/test/integration/storage/service/test_CoreAlignmentService.py
@@ -135,6 +135,14 @@ def test_snippy_core_align(core_alignment_service: CoreAlignmentService, expecte
     compare_alignments(expected_alignment_core, actual_alignment)
 
 
+def test_snippy_core_align_with_other_include(core_alignment_service: CoreAlignmentService):
+    with pytest.raises(Exception) as execinfo:
+        core_alignment_service.construct_alignment(reference_name='genome',
+                                                                      samples=['SampleA', 'SampleB', 'SampleC'],
+                                                                      include_expression='TYPE="INDEL"')
+    assert 'Currently align_type=core only works with include_expression=\'TYPE="SNP"\'' in str(execinfo.value)
+
+
 def test_snippy_full_align(core_alignment_service, expected_alignment_full):
     actual_alignment = core_alignment_service.construct_alignment(reference_name='genome',
                                                                   samples=['SampleA', 'SampleB', 'SampleC'],

--- a/genomics_data_index/test/integration/storage/service/test_CoreAlignmentService.py
+++ b/genomics_data_index/test/integration/storage/service/test_CoreAlignmentService.py
@@ -138,9 +138,18 @@ def test_snippy_core_align(core_alignment_service: CoreAlignmentService, expecte
 def test_snippy_core_align_with_other_include(core_alignment_service: CoreAlignmentService):
     with pytest.raises(Exception) as execinfo:
         core_alignment_service.construct_alignment(reference_name='genome',
-                                                                      samples=['SampleA', 'SampleB', 'SampleC'],
-                                                                      include_expression='TYPE="INDEL"')
-    assert 'Currently align_type=core only works with include_expression=\'TYPE="SNP"\'' in str(execinfo.value)
+                                                   samples=['SampleA', 'SampleB', 'SampleC'],
+                                                   include_variants=['MNP'])
+    assert 'Currently align_type=core only works with include_variants=["SNP"]' in str(execinfo.value)
+
+
+def test_snippy_full_align_with_invalid_include_variants(core_alignment_service: CoreAlignmentService):
+    with pytest.raises(Exception) as execinfo:
+        core_alignment_service.construct_alignment(reference_name='genome',
+                                                   samples=['SampleA', 'SampleB', 'SampleC'],
+                                                   align_type='full',
+                                                   include_variants=['invalid'])
+    assert f"Only {['SNP', 'MNP', 'INDEL', 'OTHER']} are supported" in str(execinfo.value)
 
 
 def test_snippy_full_align(core_alignment_service, expected_alignment_full):

--- a/genomics_data_index/test/integration/storage/service/test_CoreAlignmentService.py
+++ b/genomics_data_index/test/integration/storage/service/test_CoreAlignmentService.py
@@ -149,7 +149,7 @@ def test_snippy_full_align_with_invalid_include_variants(core_alignment_service:
                                                    samples=['SampleA', 'SampleB', 'SampleC'],
                                                    align_type='full',
                                                    include_variants=['invalid'])
-    assert f"Only {['SNP', 'MNP', 'INDEL', 'OTHER']} are supported" in str(execinfo.value)
+    assert f"Only {['SNP', 'MNP']} are supported" in str(execinfo.value)
 
 
 def test_snippy_full_align(core_alignment_service, expected_alignment_full):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(name='genomics-data-index',
-      version='0.3.0.dev2',
+      version='0.3.0.dev3',
       description='Indexes genomics data (mutations, kmers, MLST) for fast querying of features.',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
* Added a **Type** column to the output of `query.features_summary()` or `db.mutations_summary()` which will display the variant type (e.g., `SNP`, `MNP`, `INDEL, `OTHER`)
* Added ability to configure which variants to include in an alignment/building a tree (instead of just `TYPE="SNP"`).