### PR TITLE
Feature/query general

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [api]: Added method to define custom `q.isa()` methods and implemented a method to type SARS-CoV-2 genomes using [constellations](https://github.com/cov-lineages/constellations) of mutations (the SARS-CoV-2 typer should be considered experimental at this stage and is not guaranteed to work in all cases) (0.3.0.dev9).
 * [api]: Loading both VCFs and Kmer sketches listed in the same file (0.3.0.dev10).
 * [analysis]: Changed default option to `--use-conda` for analysis.
-* [cli]: Added general query command for multiple types of queries (`gdi query hasa:feature` or `gdi query isa:sample`).
+* [cli]: Added general query command for multiple types of queries (`gdi query hasa:feature` or `gdi query isa:sample`) as well as summarizing features (`--features-summary`).
 
 # 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 * [api]: Added method to define custom `q.isa()` methods and implemented a method to type SARS-CoV-2 genomes using [constellations](https://github.com/cov-lineages/constellations) of mutations (the SARS-CoV-2 typer should be considered experimental at this stage and is not guaranteed to work in all cases) (0.3.0.dev9).
 * [api]: Loading both VCFs and Kmer sketches listed in the same file (0.3.0.dev10).
 * [analysis]: Changed default option to `--use-conda` for analysis.
-* [cli]: Added general query command for multiple types of queries (`gdi query hasa:feature` or `gdi query isa:sample`) as well as summarizing features (`--features-summary`).
+* [cli]: Added general query command for multiple types of queries (`gdi query hasa:feature` or `gdi query isa:sample`) as well as summarizing features (`--features-summary`) (0.3.0.dev11).
+* [cli]: Renamed `--summarize` to `--summary` for CLI (0.3.0.dev11).
 
 # 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [api]: Added method to define custom `q.isa()` methods and implemented a method to type SARS-CoV-2 genomes using [constellations](https://github.com/cov-lineages/constellations) of mutations (the SARS-CoV-2 typer should be considered experimental at this stage and is not guaranteed to work in all cases) (0.3.0.dev9).
 * [api]: Loading both VCFs and Kmer sketches listed in the same file (0.3.0.dev10).
 * [analysis]: Changed default option to `--use-conda` for analysis.
-* [cli]: Added general query command for all types of features (`gdi query [features]`).
+* [cli]: Added general query command for multiple types of queries (`gdi query hasa:feature` or `gdi query isa:sample`).
 
 # 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [api]: Added method to define custom `q.isa()` methods and implemented a method to type SARS-CoV-2 genomes using [constellations](https://github.com/cov-lineages/constellations) of mutations (the SARS-CoV-2 typer should be considered experimental at this stage and is not guaranteed to work in all cases) (0.3.0.dev9).
 * [api]: Loading both VCFs and Kmer sketches listed in the same file (0.3.0.dev10).
 * [analysis]: Changed default option to `--use-conda` for analysis.
+* [cli]: Added general query command for all types of features (`gdi query [features]`).
 
 # 0.2.0
 

--- a/genomics_data_index/__init__.py
+++ b/genomics_data_index/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = '0.3.0.dev10'
+__version__: str = '0.3.0.dev11'

--- a/genomics_data_index/api/query/SamplesQuery.py
+++ b/genomics_data_index/api/query/SamplesQuery.py
@@ -7,9 +7,9 @@ import numpy as np
 import pandas as pd
 from ete3 import Tree
 
+from genomics_data_index.api.query.kind.IsaKind import IsaKind
 from genomics_data_index.storage.SampleSet import SampleSet
 from genomics_data_index.storage.model.QueryFeature import QueryFeature
-from genomics_data_index.api.query.kind.IsaKind import IsaKind
 
 
 class SamplesQuery(abc.ABC):

--- a/genomics_data_index/api/query/impl/SamplesQueryIndex.py
+++ b/genomics_data_index/api/query/impl/SamplesQueryIndex.py
@@ -15,13 +15,13 @@ from genomics_data_index.api.query.features.MutationFeaturesFromIndexComparator 
 from genomics_data_index.api.query.impl.DataFrameSamplesQuery import DataFrameSamplesQuery
 from genomics_data_index.api.query.impl.QueriesCollection import QueriesCollection
 from genomics_data_index.api.query.impl.TreeSamplesQueryFactory import TreeSamplesQueryFactory
+from genomics_data_index.api.query.kind.IsaKind import IsaKind
+from genomics_data_index.api.query.kind.isa.DelegateIsaKind import DelegateIsaKind
 from genomics_data_index.configuration.connector import DataIndexConnection
 from genomics_data_index.storage.SampleSet import SampleSet
 from genomics_data_index.storage.model.QueryFeature import QueryFeature
 from genomics_data_index.storage.model.QueryFeatureFactory import QueryFeatureFactory
 from genomics_data_index.storage.service.KmerService import KmerService
-from genomics_data_index.api.query.kind.IsaKind import IsaKind
-from genomics_data_index.api.query.kind.isa.DelegateIsaKind import DelegateIsaKind
 
 logger = logging.getLogger(__name__)
 

--- a/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
@@ -7,11 +7,11 @@ import numpy as np
 import pandas as pd
 
 from genomics_data_index.api.query.SamplesQuery import SamplesQuery
+from genomics_data_index.api.query.kind.IsaKind import IsaKind
+from genomics_data_index.api.query.kind.isa.DelegateIsaKind import DelegateIsaKind
 from genomics_data_index.configuration.connector import DataIndexConnection
 from genomics_data_index.storage.SampleSet import SampleSet
 from genomics_data_index.storage.model.QueryFeature import QueryFeature
-from genomics_data_index.api.query.kind.IsaKind import IsaKind
-from genomics_data_index.api.query.kind.isa.DelegateIsaKind import DelegateIsaKind
 
 
 class WrappedSamplesQuery(SamplesQuery, abc.ABC):

--- a/genomics_data_index/api/query/kind/isa/DelegateIsaKind.py
+++ b/genomics_data_index/api/query/kind/isa/DelegateIsaKind.py
@@ -1,8 +1,8 @@
 import abc
 from typing import Union, List
 
-from genomics_data_index.api.query.kind.IsaKind import IsaKind
 from genomics_data_index.api.query.SamplesQuery import SamplesQuery
+from genomics_data_index.api.query.kind.IsaKind import IsaKind
 from genomics_data_index.storage.SampleSet import SampleSet
 
 

--- a/genomics_data_index/api/query/kind/isa/typing/ExperimentalSARSCov2ConstellationsTyper.py
+++ b/genomics_data_index/api/query/kind/isa/typing/ExperimentalSARSCov2ConstellationsTyper.py
@@ -1,9 +1,9 @@
-from typing import List, Dict, Set, Any, Union
-from pathlib import Path
-import logging
 import json
-from collections import Counter
+import logging
 import re
+from collections import Counter
+from pathlib import Path
+from typing import List, Dict, Set, Any, Union
 
 from Bio.SeqRecord import SeqRecord
 
@@ -37,13 +37,15 @@ class ExperimentalSARSCov2ConstellationsTyper(SamplesTypingIsaKind):
 
         sequence_name = str(sequence.id)
         if sequence_name not in ['NC_045512.2', 'NC_045512']:
-            logger.warning(f"sequence_name=[{sequence_name}] is not 'NC_045512.2' or 'NC_045512'. This is what the constellations are with respect"
-                            "to <https://github.com/cov-lineages/constellations/blob/main/constellations/data/SARS-CoV-2.json>")
+            logger.warning(
+                f"sequence_name=[{sequence_name}] is not 'NC_045512.2' or 'NC_045512'. This is what the constellations are with respect"
+                "to <https://github.com/cov-lineages/constellations/blob/main/constellations/data/SARS-CoV-2.json>")
 
         self._sequence_name = sequence_name
         self._sequence = sequence
         if valid_gene_identifiers is None:
-            self._valid_gene_identifiers = {'ORF1ab', 'S', 'ORF3a', 'E', 'M', 'ORF6', 'ORF7a', 'ORF7b', 'ORF8', 'N', 'ORF10'}
+            self._valid_gene_identifiers = {'ORF1ab', 'S', 'ORF3a', 'E', 'M', 'ORF6', 'ORF7a', 'ORF7b', 'ORF8', 'N',
+                                            'ORF10'}
         self._typing_definitions = self._parse_definitions(constellation_files)
         self._perfect_match_only = perfect_match_only
 
@@ -209,7 +211,8 @@ class ExperimentalSARSCov2ConstellationsTyper(SamplesTypingIsaKind):
     def type_names(self) -> List[str]:
         return list(self._typing_definitions.keys())
 
-    def perfect_matches(self, type_name: str, query: SamplesQuery, signature_mutations: Set[str] = None) -> SamplesQuery:
+    def perfect_matches(self, type_name: str, query: SamplesQuery,
+                        signature_mutations: Set[str] = None) -> SamplesQuery:
         self._validate_type_name(type_name)
         if signature_mutations is None:
             signature_mutations = self._typing_definitions[type_name]['signature_mutations']

--- a/genomics_data_index/cli/gdi.py
+++ b/genomics_data_index/cli/gdi.py
@@ -1,5 +1,6 @@
 import logging
 import multiprocessing
+import re
 import shutil
 import sys
 import time
@@ -8,7 +9,6 @@ from os import getcwd, mkdir
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List, cast, Tuple
-import re
 
 import click
 import click_config_file
@@ -36,9 +36,6 @@ from genomics_data_index.storage.io.mutation.NucleotideSampleDataPackageFactory 
 from genomics_data_index.storage.io.mutation.NucleotideSampleDataPackageFactory import \
     NucleotideSnippySampleDataPackageFactory
 from genomics_data_index.storage.io.mutation.SequenceFile import SequenceFile
-from genomics_data_index.storage.model.QueryFeature import QueryFeature
-from genomics_data_index.storage.model.QueryFeatureMLST import QueryFeatureMLST
-from genomics_data_index.storage.model.QueryFeatureMutationSPDI import QueryFeatureMutationSPDI
 from genomics_data_index.storage.service import EntityExistsError
 from genomics_data_index.storage.service.CoreAlignmentService import CoreAlignmentService
 from genomics_data_index.storage.service.MLSTService import MLSTService
@@ -303,9 +300,8 @@ def load_vcf(ctx, vcf_fofns: str, reference_file: str, reference_name: str,
 @click.option('--extra-tree-params', help='Extra parameters to tree-building software',
               default=None)
 def load_vcf_kmer(ctx, vcf_kmer_fofns: str, reference_file: str, reference_name: str,
-             index_unknown: bool, sample_batch_size: int, build_tree: bool, align_type: str,
-             include_variants: Tuple[str], extra_tree_params: str):
-
+                  index_unknown: bool, sample_batch_size: int, build_tree: bool, align_type: str,
+                  include_variants: Tuple[str], extra_tree_params: str):
     logger.info(f'Indexing processed VCF files defined in [{vcf_kmer_fofns}]')
     ctx.invoke(load_vcf, index_unknown=index_unknown, vcf_fofns=vcf_kmer_fofns,
                reference_file=reference_file, reference_name=reference_name,
@@ -905,7 +901,8 @@ def perform_query(query: SamplesQuery, command: str) -> SamplesQuery:
 @main.command(name='query')
 @click.pass_context
 @click.argument('query_command', nargs=-1)
-@click.option('--reference-name', type=str, required=False, help='Reference genome name for querying by phylogenetic distance')
+@click.option('--reference-name', type=str, required=False,
+              help='Reference genome name for querying by phylogenetic distance')
 @click.option('--summary/--no-summary', help='Print summary information on query')
 @click.option('--features-summary', required=False,
               type=click.Choice(SamplesQueryIndex.SUMMARY_FEATURES_KINDS),

--- a/genomics_data_index/cli/gdi.py
+++ b/genomics_data_index/cli/gdi.py
@@ -876,43 +876,22 @@ def rebuild_tree(ctx, reference: List[str], align_type: str, include_variants: T
         logger.info(f'Finished rebuilding tree')
 
 
-@main.group()
+@main.command(name='query')
 @click.pass_context
-def query(ctx):
-    pass
-
-
-def query_feature(genomics_index: GenomicsDataIndex, features: List[QueryFeature], summarize: bool) -> None:
+@click.argument('features', nargs=-1)
+@click.option('--summary/--no-summary', help='Print summary information on query')
+def query(ctx, features: List[str], summary: bool):
+    genomics_index = get_genomics_index(ctx)
     query = genomics_index.samples_query()
     for feature in features:
         query = query.hasa(feature)
 
-    if summarize:
+    if summary:
         results_df = query.summary()
     else:
         results_df = query.toframe(include_unknown=True)
 
     results_df.to_csv(sys.stdout, sep='\t', index=False, float_format='%0.4g', na_rep='-')
-
-
-@query.command(name='mutation')
-@click.pass_context
-@click.argument('name', nargs=-1)
-@click.option('--summarize/--no-summarize', help='Print summary information on query')
-def query_mutation(ctx, name: List[str], summarize: bool):
-    genomics_index = get_genomics_index(ctx)
-    features = [QueryFeatureMutationSPDI(n) for n in name]
-    query_feature(genomics_index=genomics_index, features=features, summarize=summarize)
-
-
-@query.command(name='mlst')
-@click.pass_context
-@click.argument('name', nargs=-1)
-@click.option('--summarize/--no-summarize', help='Print summary information on query')
-def query_mlst(ctx, name: List[str], summarize: bool):
-    genomics_index = get_genomics_index(ctx)
-    features = [QueryFeatureMLST(n) for n in name]
-    query_feature(genomics_index=genomics_index, features=features, summarize=summarize)
 
 
 @main.group(name='db')

--- a/genomics_data_index/test/integration/storage/service/test_TreeService.py
+++ b/genomics_data_index/test/integration/storage/service/test_TreeService.py
@@ -15,7 +15,7 @@ def test_build_tree_core_fasttree(tree_service, core_alignment_service, expected
         include_variants=['SNP'], align_type='core',
     )
 
-    tree, out = tree_service.build_tree(alignment, tree_build_type='fasttree',)
+    tree, out = tree_service.build_tree(alignment, tree_build_type='fasttree', )
 
     assert {'SampleA', 'SampleB', 'SampleC', 'genome'} == set(tree.get_leaf_names())
 

--- a/genomics_data_index/test/unit/api/query/kind/test_ExperimentalSARSCov2ConstellationsTyper.py
+++ b/genomics_data_index/test/unit/api/query/kind/test_ExperimentalSARSCov2ConstellationsTyper.py
@@ -1,11 +1,12 @@
-import pytest
 import gzip
-from pathlib import Path
 from os import path
+from pathlib import Path
 
+import pytest
 from Bio import SeqIO
 
-from genomics_data_index.api.query.kind.isa.typing.ExperimentalSARSCov2ConstellationsTyper import ExperimentalSARSCov2ConstellationsTyper
+from genomics_data_index.api.query.kind.isa.typing.ExperimentalSARSCov2ConstellationsTyper import \
+    ExperimentalSARSCov2ConstellationsTyper
 
 root_data_dir = Path(path.dirname(__file__)) / '..' / '..' / '..' / 'data'
 sequence_path = root_data_dir / 'NC_045512.2.gb.gz'

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(name='genomics-data-index',
-      version='0.3.0.dev10',
+      version='0.3.0.dev11',
       description='Indexes genomics data (mutations, kmers, MLST) for fast querying of features.',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
* Added support for a more general method of querying for features in the CLI. Mainly by using strings like `hasa:MUTATION`, `isa:SAMPLE`, `isin_2_substitutions:SAMPLE`.
* Added a `--features-summary` and `--features-summary-unique` command-line switches to query command to summarize features in query.
* Renamed `--summarize` to `--summary`.