### PR TITLE
Feature/tree node nosize

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -34,7 +34,7 @@ jobs:
           conda config --add channels defaults
           conda config --add channels conda-forge
           conda config --add channels bioconda
-          conda install mamba setuptools=57 htslib bcftools==1.12 samtools bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
+          conda install mamba setuptools=57 htslib bcftools==1.12 samtools==1.12 bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
 
       - name: Setup python packages
         shell: bash -l {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 * [api]: Implemented a `prune()` method for pruning a tree down to only the selected samples (0.4.0.dev1).
 * [api]: Fixed bug where `query.join_tree()` was pruning the original tree (instead of a copy) (0.4.0.dev1).
 * [cli]: Fixed bug where `--features-summary mlst` would not work in command-line interface (0.4.0.dev1).
-* [api]: Changed default NodeStyle for rendering trees such that nodes have size 0 (avoids inflating distances when many samples have distance 0). (0.4.0.dev2)
+* [api]: Changed default NodeStyle for rendering trees such that nodes have size 0 (avoids inflating distances when many samples have distance 0) 0.4.0.dev2).
+* [api]: Adding ability to more easily set highlight colours (0.4.0.dev2).
 
 # 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [api]: Implemented a `prune()` method for pruning a tree down to only the selected samples (0.4.0.dev1).
 * [api]: Fixed bug where `query.join_tree()` was pruning the original tree (instead of a copy) (0.4.0.dev1).
 * [cli]: Fixed bug where `--features-summary mlst` would not work in command-line interface (0.4.0.dev1).
+* [api]: Changed default NodeStyle for rendering trees such that nodes have size 0 (avoids inflating distances when many samples have distance 0). (0.4.0.dev2)
 
 # 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [api]: Implemented a `prune()` method for pruning a tree down to only the selected samples (0.4.0.dev1).
 * [api]: Fixed bug where `query.join_tree()` was pruning the original tree (instead of a copy) (0.4.0.dev1).
 * [cli]: Fixed bug where `--features-summary mlst` would not work in command-line interface (0.4.0.dev1).
-* [api]: Changed default NodeStyle for rendering trees such that nodes have size 0 (avoids inflating distances when many samples have distance 0) 0.4.0.dev2).
+* [api]: Changed default NodeStyle for rendering trees such that nodes have size 0, which avoids inflating distances when many samples have distance 0 (0.4.0.dev2).
 * [api]: Adding ability to more easily set highlight colours and adjusted default node colours for highlights (0.4.0.dev2).
 * [api]: Added ability to pre-render a tree and included additional parameters for rendering (0.4.0.dev2).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [cli]: Fixed bug where `--features-summary mlst` would not work in command-line interface (0.4.0.dev1).
 * [api]: Changed default NodeStyle for rendering trees such that nodes have size 0 (avoids inflating distances when many samples have distance 0) 0.4.0.dev2).
 * [api]: Adding ability to more easily set highlight colours (0.4.0.dev2).
+* [api]: Added ability to pre-render a tree (0.4.0.dev2).
 
 # 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [cli]: Fixed bug where `--features-summary mlst` would not work in command-line interface (0.4.0.dev1).
 * [api]: Changed default NodeStyle for rendering trees such that nodes have size 0 (avoids inflating distances when many samples have distance 0) 0.4.0.dev2).
 * [api]: Adding ability to more easily set highlight colours and adjusted default node colours for highlights (0.4.0.dev2).
-* [api]: Added ability to pre-render a tree (0.4.0.dev2).
+* [api]: Added ability to pre-render a tree and included additional parameters for rendering (0.4.0.dev2).
 
 # 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [api]: Fixed bug where `query.join_tree()` was pruning the original tree (instead of a copy) (0.4.0.dev1).
 * [cli]: Fixed bug where `--features-summary mlst` would not work in command-line interface (0.4.0.dev1).
 * [api]: Changed default NodeStyle for rendering trees such that nodes have size 0 (avoids inflating distances when many samples have distance 0) 0.4.0.dev2).
-* [api]: Adding ability to more easily set highlight colours (0.4.0.dev2).
+* [api]: Adding ability to more easily set highlight colours and adjusted default node colours for highlights (0.4.0.dev2).
 * [api]: Added ability to pre-render a tree (0.4.0.dev2).
 
 # 0.3.0

--- a/genomics_data_index/__init__.py
+++ b/genomics_data_index/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = '0.4.0.dev1'
+__version__: str = '0.4.0.dev2'

--- a/genomics_data_index/api/query/impl/TreeSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/TreeSamplesQuery.py
@@ -4,7 +4,7 @@ import abc
 import logging
 from typing import Union, List, cast
 
-from ete3 import Tree, TreeStyle
+from ete3 import Tree, TreeStyle, NodeStyle
 
 from genomics_data_index.api.query.SamplesQuery import SamplesQuery
 from genomics_data_index.api.query.impl.WrappedSamplesQuery import WrappedSamplesQuery
@@ -188,6 +188,7 @@ class TreeSamplesQuery(WrappedSamplesQuery, abc.ABC):
                     initial_style: TreeStyle = None,
                     mode='r',
                     highlight_style: Union[str, HighlightStyle] = 'pastel',
+                    node_style: NodeStyle = None,
                     legend_nsize: int = 20, legend_fsize: int = 11,
                     annotate_color_present: str = 'black',
                     annotate_color_absent: str = 'white',
@@ -230,6 +231,7 @@ class TreeSamplesQuery(WrappedSamplesQuery, abc.ABC):
         :param highlight_style: A style used to define how the highlight() method should behave.
                                 Can either be one of the named highlight styles ['light', 'light_hn', 'pastel', 'medium', dark']
                                 or an instance of a :py:class:`genomics_data_index.api.viewer.TreeStyler.HighlightStyle`.
+        :param node_style: The default ete3.NodeStyle object for styling the nodes of the tree.
         :param legend_nsize: The legend node size.
         :param legend_fsize: The legend font size.
         :param annotate_color_present: The default color of samples which are present in the set for the annotate() method.
@@ -272,6 +274,7 @@ class TreeSamplesQuery(WrappedSamplesQuery, abc.ABC):
                                  initial_style=initial_style,
                                  mode=mode,
                                  highlight_style=highlight_style,
+                                 node_style=node_style,
                                  legend_nsize=legend_nsize,
                                  legend_fsize=legend_fsize,
                                  annotate_color_present=annotate_color_present,

--- a/genomics_data_index/api/viewer/TreeStyler.py
+++ b/genomics_data_index/api/viewer/TreeStyler.py
@@ -715,7 +715,7 @@ class HighlightStyle:
             raise Exception(f'fg_colors={fg_colors} and bg_colors={bg_colors} do not have the same length')
 
         styles = []
-        for i in range(0, len(fg_colors)):
+        for i in range(0, len(bg_colors)):
             nstyle = copy.deepcopy(base_node_style)
             nstyle['fgcolor'] = fg_colors[i]
             nstyle['bgcolor'] = bg_colors[i]
@@ -731,7 +731,7 @@ class HighlightStyle:
             styles.append({
                 'present_nstyle': nstyle,
                 'unknown_nstyle': unknown_nstyle,
-                'legend_color': fg_colors[i]
+                'legend_color': bg_colors[i]
             })
 
         return HighlightStyle(styles, index=0)

--- a/genomics_data_index/api/viewer/TreeStyler.py
+++ b/genomics_data_index/api/viewer/TreeStyler.py
@@ -627,15 +627,25 @@ class HighlightStyle:
         return HighlightStyle(self._node_styles, index=new_index)
 
     @classmethod
-    def create(cls, kind: str, base_node_style: NodeStyle) -> HighlightStyle:
+    def create(cls, kind: str = None, colors: List[str] = None, base_node_style: NodeStyle = None) -> HighlightStyle:
         """
         Creates a new pre-defined HighlightStyle.
         :param kind: The kind (name) of the pre-defined HighlightStyle to create.
+        :param colors: A list of colors to use for highlights (unused if kind is set).
         :param base_node_style: The base node style to use.
         :return: A new HighlightStyle.
         """
         unknown_fg_color = 'lightgray'
         unknown_bg_color = 'lightgray'
+
+        if base_node_style is None:
+            base_node_style = DEFAULT_NODE_STYLE
+
+        if kind is None and colors is not None:
+            return cls._create_highlights(base_node_style=base_node_style, fg_colors=colors, bg_colors=colors,
+                                          unknown_bg_color=unknown_bg_color, unknown_fg_color=unknown_fg_color)
+        elif kind is None:
+            kind = 'light'
 
         if kind == 'light':
             fg_colors = ['#e5f5f9', '#fee8c8', '#e0ecf4', '#deebf7']

--- a/genomics_data_index/api/viewer/TreeStyler.py
+++ b/genomics_data_index/api/viewer/TreeStyler.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_NODE_STYLE = NodeStyle()
 DEFAULT_NODE_STYLE['size'] = 0
 
+
 class TreeStyler:
     """
     A class used to style and render a tree and sets of samples on this tree.
@@ -680,34 +681,35 @@ class HighlightStyle:
         unknown_fg_color = default_fg_color
 
         if kind is None and colors is not None:
-            return cls._create_highlights(base_node_style=base_node_style, fg_colors=[default_fg_color]*len(colors),
+            return cls._create_highlights(base_node_style=base_node_style, fg_colors=[default_fg_color] * len(colors),
                                           bg_colors=colors, unknown_bg_color=unknown_bg_color,
                                           unknown_fg_color=unknown_fg_color)
         elif kind is None:
             kind = 'light'
 
         if kind == 'light':
-            fg_colors = [default_fg_color]*4
+            fg_colors = [default_fg_color] * 4
             bg_colors = ['#e5f5f9', '#fee8c8', '#e0ecf4', '#deebf7']
             return cls._create_highlights(base_node_style=base_node_style, fg_colors=fg_colors, bg_colors=bg_colors,
                                           unknown_bg_color=unknown_bg_color, unknown_fg_color=unknown_fg_color)
         elif kind == 'light_hn':
             fg_colors = ['#41ae76', '#ef6548', '#8c6bb1', '#4292c6']
             bg_colors = ['#e5f5f9', '#fee8c8', '#e0ecf4', '#deebf7']
-            return cls._create_highlights(base_node_style=base_node_style, fg_colors=fg_colors, bg_colors=bg_colors, nsize=20,
+            return cls._create_highlights(base_node_style=base_node_style, fg_colors=fg_colors, bg_colors=bg_colors,
+                                          nsize=20,
                                           unknown_bg_color=unknown_bg_color, unknown_fg_color=unknown_fg_color)
         elif kind == 'pastel':
-            fg_colors = [default_fg_color]*5
+            fg_colors = [default_fg_color] * 5
             bg_colors = ['#fbb4ae', '#b3cde3', '#ccebc5', '#decbe4', '#fed9a6']
             return cls._create_highlights(base_node_style=base_node_style, fg_colors=fg_colors, bg_colors=bg_colors,
                                           unknown_bg_color=unknown_bg_color, unknown_fg_color=unknown_fg_color)
         elif kind == 'medium':
-            fg_colors = [default_fg_color]*5
+            fg_colors = [default_fg_color] * 5
             bg_colors = ['#66c2a5', '#fc8d62', '#8da0cb', '#e78ac3', '#a6d854']
             return cls._create_highlights(base_node_style=base_node_style, fg_colors=fg_colors, bg_colors=bg_colors,
                                           unknown_bg_color=unknown_bg_color, unknown_fg_color=unknown_fg_color)
         elif kind == 'dark':
-            fg_colors = [default_fg_color]*5
+            fg_colors = [default_fg_color] * 5
             bg_colors = ['#1b9e77', '#d95f02', '#7570b3', '#e7298a', '#66a61e']
             return cls._create_highlights(base_node_style=base_node_style, fg_colors=fg_colors, bg_colors=bg_colors,
                                           unknown_bg_color=unknown_bg_color, unknown_fg_color=unknown_fg_color)

--- a/genomics_data_index/api/viewer/TreeStyler.py
+++ b/genomics_data_index/api/viewer/TreeStyler.py
@@ -664,21 +664,24 @@ class HighlightStyle:
         :param base_node_style: The base node style to use.
         :return: A new HighlightStyle.
         """
-        unknown_fg_color = 'lightgray'
         unknown_bg_color = 'lightgray'
 
         if base_node_style is None:
             base_node_style = DEFAULT_NODE_STYLE
 
+        default_fg_color = base_node_style['fgcolor']
+        unknown_fg_color = default_fg_color
+
         if kind is None and colors is not None:
-            return cls._create_highlights(base_node_style=base_node_style, fg_colors=colors, bg_colors=colors,
-                                          unknown_bg_color=unknown_bg_color, unknown_fg_color=unknown_fg_color)
+            return cls._create_highlights(base_node_style=base_node_style, fg_colors=[default_fg_color]*len(colors),
+                                          bg_colors=colors, unknown_bg_color=unknown_bg_color,
+                                          unknown_fg_color=unknown_fg_color)
         elif kind is None:
             kind = 'light'
 
         if kind == 'light':
-            fg_colors = ['#e5f5f9', '#fee8c8', '#e0ecf4', '#deebf7']
-            bg_colors = fg_colors
+            fg_colors = [default_fg_color]*4
+            bg_colors = ['#e5f5f9', '#fee8c8', '#e0ecf4', '#deebf7']
             return cls._create_highlights(base_node_style=base_node_style, fg_colors=fg_colors, bg_colors=bg_colors,
                                           unknown_bg_color=unknown_bg_color, unknown_fg_color=unknown_fg_color)
         elif kind == 'light_hn':
@@ -687,18 +690,18 @@ class HighlightStyle:
             return cls._create_highlights(base_node_style=base_node_style, fg_colors=fg_colors, bg_colors=bg_colors, nsize=20,
                                           unknown_bg_color=unknown_bg_color, unknown_fg_color=unknown_fg_color)
         elif kind == 'pastel':
-            fg_colors = ['#fbb4ae', '#b3cde3', '#ccebc5', '#decbe4', '#fed9a6']
-            bg_colors = fg_colors
+            fg_colors = [default_fg_color]*5
+            bg_colors = ['#fbb4ae', '#b3cde3', '#ccebc5', '#decbe4', '#fed9a6']
             return cls._create_highlights(base_node_style=base_node_style, fg_colors=fg_colors, bg_colors=bg_colors,
                                           unknown_bg_color=unknown_bg_color, unknown_fg_color=unknown_fg_color)
         elif kind == 'medium':
-            fg_colors = ['#66c2a5', '#fc8d62', '#8da0cb', '#e78ac3', '#a6d854']
-            bg_colors = fg_colors
+            fg_colors = [default_fg_color]*5
+            bg_colors = ['#66c2a5', '#fc8d62', '#8da0cb', '#e78ac3', '#a6d854']
             return cls._create_highlights(base_node_style=base_node_style, fg_colors=fg_colors, bg_colors=bg_colors,
                                           unknown_bg_color=unknown_bg_color, unknown_fg_color=unknown_fg_color)
         elif kind == 'dark':
-            fg_colors = ['#1b9e77', '#d95f02', '#7570b3', '#e7298a', '#66a61e']
-            bg_colors = fg_colors
+            fg_colors = [default_fg_color]*5
+            bg_colors = ['#1b9e77', '#d95f02', '#7570b3', '#e7298a', '#66a61e']
             return cls._create_highlights(base_node_style=base_node_style, fg_colors=fg_colors, bg_colors=bg_colors,
                                           unknown_bg_color=unknown_bg_color, unknown_fg_color=unknown_fg_color)
         else:

--- a/genomics_data_index/api/viewer/TreeStyler.py
+++ b/genomics_data_index/api/viewer/TreeStyler.py
@@ -303,7 +303,8 @@ class TreeStyler:
             samples_style.apply_visual(tree=tree, tree_style=tree_style)
 
     def render(self, file_name: str = '%%inline', w: int = None, h: int = None,
-               tree_style: TreeStyle = None, units: str = 'px', dpi: int = 90):
+               tree_style: TreeStyle = None, units: str = 'px', dpi: int = 90,
+               ladderize: bool = False):
         """
         Renders the tree with the styles defined by this TreeStyler object to an image.
         :param file_name: The image file name to save, use '%%inline' to draw inline in Jupyter notebooks (default).
@@ -312,6 +313,7 @@ class TreeStyler:
         :param tree_style: The ete3.TreeStyle object (overrides the object defined by this TreeStyler).
         :param units: The units of the width/height (default in pixels).
         :param dpi: The dots per inch.
+        :param ladderize: Runs ete3.Tree.ladderize() to sort branches of a given tree according to size.
         :return: An image/image data of the drawn tree styled according to this TreeStyler.
         """
 
@@ -322,16 +324,17 @@ class TreeStyler:
         if w is None and h is None:
             w = 400
 
-        tree, tree_style = self.prerender(tree_style=tree_style)
+        tree, tree_style = self.prerender(tree_style=tree_style, ladderize=ladderize)
 
         return self.draw(tree=tree, tree_style=tree_style,
                          file_name=file_name, w=w, h=h,
                          units=units, dpi=dpi)
 
-    def prerender(self, tree_style: TreeStyle = None) -> Tuple[Tree, TreeStyle]:
+    def prerender(self, tree_style: TreeStyle = None, ladderize: bool = False) -> Tuple[Tree, TreeStyle]:
         """
         Pre-renders the tree, returning an ete3.Tree and ete3.TreeStyle object which can be used to draw the tree.
         :param tree_style: The ete3.TreeStyle object (overrides the object defined by this TreeStyler).
+        :param ladderize: Runs ete3.Tree.ladderize() to sort branches of a given tree according to size.
         :return: A tuple of <ete3.Tree, ete3.TreeStyle> with highlights/annotations added.
         """
         if tree_style is None:
@@ -345,6 +348,10 @@ class TreeStyler:
             n.set_style(self._node_style)
 
         self._apply_samples_styles(tree=tree, tree_style=tree_style)
+
+        if ladderize:
+            tree.ladderize()
+
         return tree, tree_style
 
     @classmethod

--- a/genomics_data_index/api/viewer/TreeStyler.py
+++ b/genomics_data_index/api/viewer/TreeStyler.py
@@ -719,7 +719,7 @@ class HighlightStyle:
             if nsize is not None:
                 nstyle['size'] = nsize
 
-            unknown_nstyle = NodeStyle()
+            unknown_nstyle = copy.deepcopy(base_node_style)
             unknown_nstyle['fgcolor'] = unknown_fg_color
             unknown_nstyle['bgcolor'] = unknown_bg_color
             if nsize is not None:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(name='genomics-data-index',
-      version='0.4.0.dev1',
+      version='0.4.0.dev2',
       description='Indexes genomics data (mutations, kmers, MLST) for fast querying of features.',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixed up tree visualization:

1. Changed default NodeStyle so that the node does not have a size.
2. Better support for setting highlight colours.
3. Pre-rendering a tree.

For (1) it changed the default style to add a small blue circle to nodes:

![image](https://user-images.githubusercontent.com/200517/142209787-bc6e6d0e-2656-4c22-9df2-14ae217e3493.png)

To not having any size to the nodes:

![image](https://user-images.githubusercontent.com/200517/142209836-c743372b-bfeb-49f1-9d68-a4f19399ce23.png)
