### PR TITLE
Feature/skip existing samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.0
+
+* [cli]: Support for skipping non-existent paths in input file (0.5.0.dev1).
+
 # 0.4.0
 
 * [analysis]: Switched all steps to use conda in Snakemake pipeline (0.3.1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.5.0
 
 * [cli]: Support for skipping non-existent paths in input file (0.5.0.dev1).
+* [cli]: Support for skipping samples already in an index during the data analysis (0.5.0.dev1).
 
 # 0.4.0
 

--- a/genomics_data_index/__init__.py
+++ b/genomics_data_index/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = '0.5.0.dev0'
+__version__: str = '0.5.0.dev1'

--- a/genomics_data_index/cli/gdi.py
+++ b/genomics_data_index/cli/gdi.py
@@ -627,6 +627,10 @@ def input_split_file(absolute: bool, output_dir: str, output_samples_file: str, 
 @click.option('--check-files-exist/--no-check-files-exist',
               help='Check that the passed files in the input genomes file exist',
               default=True)
+@click.option('--skip-existing-samples/--no-skip-existing-samples',
+              help='Skip samples that already exist in the index. Attempts to automatically detect sample names'
+                   ' from file names if necessary.',
+              default=False)
 @click.argument('genomes', type=click.Path(exists=True), nargs=-1)
 def analysis(ctx, reference_file: str, load_data: bool, index_unknown: bool, clean: bool, build_tree: bool,
              align_type: str,
@@ -637,6 +641,7 @@ def analysis(ctx, reference_file: str, load_data: bool, index_unknown: bool, cle
              kmer_size: List[int], kmer_scaled: int,
              batch_size: int, sample_batch_size: int,
              input_genomes_file: str, input_structured_genomes_file: str, check_files_exist: bool,
+             skip_existing_samples: bool,
              genomes: List[str]):
     project = get_project_exit_on_error(ctx)
     data_index_connection = project.create_connection()
@@ -687,6 +692,10 @@ def analysis(ctx, reference_file: str, load_data: bool, index_unknown: bool, cle
     if sample_files is None:
         logger.info(f'Automatically structuring {len(genome_paths)} input files into assemblies/reads')
         sample_files = pipeline_executor.create_input_sample_files(genome_paths)
+
+    if skip_existing_samples:
+        existing_samples = set(GenomicsDataIndex.connect(project=project).sample_names())
+        sample_files = pipeline_executor.skip_samples_from_input_files(sample_files, skip_samples=existing_samples)
 
     logger.info(f'Processing {len(sample_files)} genomes to identify mutations')
     results = pipeline_executor.execute(sample_files=sample_files,

--- a/genomics_data_index/cli/gdi.py
+++ b/genomics_data_index/cli/gdi.py
@@ -442,6 +442,7 @@ def read_genomes_from_file(input_file: Path, check_files_exist: bool) -> List[Pa
     with open(input_file, 'r') as fh:
         genome_paths = []
         skipped = 0
+        total = 0
         for line in fh.readlines():
             line = line.strip()
             genome_path = Path(line)
@@ -450,8 +451,9 @@ def read_genomes_from_file(input_file: Path, check_files_exist: bool) -> List[Pa
                 skipped += 1
             else:
                 genome_paths.append(genome_path)
+            total += 1
         if skipped > 0:
-            logger.warning(f'Skipped {skipped} genome paths which do not exist from file {input_file}')
+            logger.warning(f'Skipped {skipped}/{total} genome paths which do not exist from file {input_file}')
         return genome_paths
 
 

--- a/genomics_data_index/cli/gdi.py
+++ b/genomics_data_index/cli/gdi.py
@@ -641,7 +641,8 @@ def analysis(ctx, reference_file: str, load_data: bool, index_unknown: bool, cle
              reads_mincov: int, reads_minqual: int,
              kmer_size: List[int], kmer_scaled: int,
              batch_size: int, sample_batch_size: int,
-             input_genomes_file: str, input_structured_genomes_file: str, check_files_exist: bool,
+             input_genomes_file: str, input_structured_genomes_file: str,
+             check_files_exist: bool,
              skip_existing_samples: bool,
              genomes: List[str]):
     project = get_project_exit_on_error(ctx)
@@ -698,6 +699,13 @@ def analysis(ctx, reference_file: str, load_data: bool, index_unknown: bool, cle
         existing_samples = set(GenomicsDataIndex.connect(project=project).sample_names())
         sample_files = pipeline_executor.skip_samples_from_input_files(sample_files, skip_samples=existing_samples)
 
+    if check_files_exist:
+        sample_files = pipeline_executor.skip_missing_sample_files(sample_files)
+
+    if len(sample_files) == 0:
+        logger.info('No samples to process, exiting.')
+        sys.exit(0)
+        
     logger.info(f'Processing {len(sample_files)} genomes to identify mutations')
     results = pipeline_executor.execute(sample_files=sample_files,
                                         reference_file=Path(reference_file),

--- a/genomics_data_index/cli/gdi.py
+++ b/genomics_data_index/cli/gdi.py
@@ -8,7 +8,7 @@ from functools import partial
 from os import getcwd, mkdir
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import List, cast, Tuple, Optional, Set
+from typing import List, cast, Tuple, Optional
 
 import click
 import click_config_file
@@ -705,7 +705,7 @@ def analysis(ctx, reference_file: str, load_data: bool, index_unknown: bool, cle
     if len(sample_files) == 0:
         logger.info('No samples to process, exiting.')
         sys.exit(0)
-        
+
     logger.info(f'Processing {len(sample_files)} genomes to identify mutations')
     results = pipeline_executor.execute(sample_files=sample_files,
                                         reference_file=Path(reference_file),

--- a/genomics_data_index/cli/gdi.py
+++ b/genomics_data_index/cli/gdi.py
@@ -429,14 +429,14 @@ def list_samples(ctx):
     click.echo('\n'.join(samples))
 
 
-def read_genomes_from_file(input_file: Path, skip_missing: bool) -> List[Path]:
+def read_genomes_from_file(input_file: Path, check_files_exist: bool) -> List[Path]:
     with open(input_file, 'r') as fh:
         genome_paths = []
         skipped = 0
         for line in fh.readlines():
             line = line.strip()
             genome_path = Path(line)
-            if skip_missing and not genome_path.exists():
+            if check_files_exist and not genome_path.exists():
                 logger.log(TRACE_LEVEL, f'Genome {genome_path} does not exist, skipping...')
                 skipped += 1
             else:
@@ -453,15 +453,16 @@ def read_genomes_from_file(input_file: Path, skip_missing: bool) -> List[Path]:
                    ' to passing genomes as arguments on the command-line',
               type=click.Path(exists=True),
               required=False)
-@click.option('--skip-missing/--no-skip-missing', help='Skip files that are missing/don\'t exist in input file',
+@click.option('--check-files-exist/--no-check-files-exist',
+              help='Check that the passed files in the input genomes file exist',
               default=True)
 @click.argument('genomes', type=click.Path(exists=True), nargs=-1)
-def input_command(absolute: bool, input_genomes_file: str, skip_missing: bool, genomes: List[str]):
+def input_command(absolute: bool, input_genomes_file: str, check_files_exist: bool, genomes: List[str]):
     if input_genomes_file is not None:
         if len(genomes) > 0:
             logger.warning(f'--input-genomes-file=[{input_genomes_file}] is specified so will ignore genomes '
                            f'passed on the command-line.')
-        genome_paths = read_genomes_from_file(Path(input_genomes_file), skip_missing=skip_missing)
+        genome_paths = read_genomes_from_file(Path(input_genomes_file), check_files_exist=check_files_exist)
     elif len(genomes) > 0:
         genome_paths = [Path(f) for f in genomes]
     else:

--- a/genomics_data_index/cli/gdi.py
+++ b/genomics_data_index/cli/gdi.py
@@ -495,7 +495,8 @@ def input_command(ctx, skip_existing_samples: bool, absolute: bool, input_genome
             samples_set = set(GenomicsDataIndex.connect(project=project).sample_names())
 
     pipeline_executor = SnakemakePipelineExecutor()
-    sample_files_df = pipeline_executor.create_input_sample_files(input_files=genome_paths, skip_samples=samples_set)
+    sample_files_df = pipeline_executor.create_input_sample_files(input_files=genome_paths)
+    sample_files_df = pipeline_executor.skip_samples_from_input_files(sample_files_df, skip_samples=samples_set)
 
     # Defaults to writing to stdout
     pipeline_executor.write_input_sample_files(input_sample_files=sample_files_df, abolute_paths=absolute)

--- a/genomics_data_index/pipelines/PipelineExecutor.py
+++ b/genomics_data_index/pipelines/PipelineExecutor.py
@@ -184,7 +184,8 @@ class PipelineExecutor(abc.ABC):
     def skip_missing_sample_files(self, samples_df: pd.DataFrame) -> pd.DataFrame:
         all_samples = len(samples_df)
         for file_col in ['Assemblies', 'Reads1', 'Reads2']:
-            files_not_na_and_exist = samples_df.loc[~samples_df[file_col].isna(), file_col].apply(lambda x: Path(x).exists())
+            files_not_na_and_exist = samples_df.loc[~samples_df[file_col].isna(), file_col].apply(
+                lambda x: Path(x).exists())
             samples_df = samples_df.loc[samples_df[file_col].isna() | files_not_na_and_exist]
 
         reduced_samples = len(samples_df)
@@ -202,7 +203,7 @@ class PipelineExecutor(abc.ABC):
             skipped_length = full_length - reduced_length
             if skipped_length > 0:
                 logger.warning(f'Skipping {skipped_length}/{full_length} samples '
-                             'since they are already indexed')
+                               'since they are already indexed')
         return samples_df
 
     def write_input_sample_files(self, input_sample_files: pd.DataFrame,

--- a/genomics_data_index/pipelines/PipelineExecutor.py
+++ b/genomics_data_index/pipelines/PipelineExecutor.py
@@ -181,13 +181,17 @@ class PipelineExecutor(abc.ABC):
                 raise Exception(f'Invalid number of files for sample [{sample}], files={reads[sample]}')
 
         samples_df = pd.DataFrame(data, columns=self.INPUT_SAMPLE_FILE_COLUMNS)
+        samples_df = self.skip_samples_from_input_files(samples_df, skip_samples=skip_samples)
 
+        return samples_df
+
+    def skip_samples_from_input_files(self, samples_df: pd.DataFrame, skip_samples: Set[str] = None):
         if not (skip_samples is None or len(skip_samples) == 0):
             full_length = len(samples_df)
             samples_df = samples_df.loc[~samples_df['Sample'].isin(skip_samples)]
             reduced_length = len(samples_df)
-            logger.debug(f'Skipping {full_length - reduced_length} samples since they are already indexed')
-
+            logger.info(f'Skipping {full_length - reduced_length}/{full_length} samples '
+                         f'since they are already indexed')
         return samples_df
 
     def write_input_sample_files(self, input_sample_files: pd.DataFrame,

--- a/genomics_data_index/pipelines/PipelineExecutor.py
+++ b/genomics_data_index/pipelines/PipelineExecutor.py
@@ -93,11 +93,10 @@ class PipelineExecutor(abc.ABC):
         restored_data = restored_data[data_columns_to_keep]
         return restored_data
 
-    def create_input_sample_files(self, input_files: List[Path], skip_samples: Set[str] = None) -> pd.DataFrame:
+    def create_input_sample_files(self, input_files: List[Path]) -> pd.DataFrame:
         """
         Create a dataframe which associates the given files with a sample entry.
         :param input_files: The list of files.
-        :param skip_samples: An optional set of sample names to skip.
         :return: A pandas.DataFrame which has one sample per row associated with the input files.
         """
         assemblies = {}
@@ -180,10 +179,7 @@ class PipelineExecutor(abc.ABC):
             else:
                 raise Exception(f'Invalid number of files for sample [{sample}], files={reads[sample]}')
 
-        samples_df = pd.DataFrame(data, columns=self.INPUT_SAMPLE_FILE_COLUMNS)
-        samples_df = self.skip_samples_from_input_files(samples_df, skip_samples=skip_samples)
-
-        return samples_df
+        return pd.DataFrame(data, columns=self.INPUT_SAMPLE_FILE_COLUMNS)
 
     def skip_samples_from_input_files(self, samples_df: pd.DataFrame, skip_samples: Set[str] = None):
         if not (skip_samples is None or len(skip_samples) == 0):

--- a/genomics_data_index/test/unit/variant/pipelines/test_SnakemakePipelineExecutor.py
+++ b/genomics_data_index/test/unit/variant/pipelines/test_SnakemakePipelineExecutor.py
@@ -175,7 +175,6 @@ def test_skip_missing_sample_files():
         assert ['B', f1, 'NA', 'NA'] == df.iloc[1].tolist()
         assert ['C', 'NA', f1, f1] == df.iloc[2].tolist()
 
-
         input_samples = pd.DataFrame([
             ['A', f1, pd.NA, pd.NA],
             ['B', Path('file2.fasta'), pd.NA, pd.NA],
@@ -187,7 +186,6 @@ def test_skip_missing_sample_files():
         assert ['Sample', 'Assemblies', 'Reads1', 'Reads2'] == df.columns.tolist()
         assert 1 == len(df)
         assert ['A', f1, 'NA', 'NA'] == df.iloc[0].tolist()
-
 
         input_samples = pd.DataFrame([
             ['A', f1, pd.NA, pd.NA],
@@ -201,7 +199,6 @@ def test_skip_missing_sample_files():
         assert 2 == len(df)
         assert ['A', f1, 'NA', 'NA'] == df.iloc[0].tolist()
         assert ['B', f1, 'NA', 'NA'] == df.iloc[1].tolist()
-
 
         input_samples = pd.DataFrame([
             ['A', f1, pd.NA, pd.NA],
@@ -215,7 +212,6 @@ def test_skip_missing_sample_files():
         assert 2 == len(df)
         assert ['A', f1, 'NA', 'NA'] == df.iloc[0].tolist()
         assert ['B', f1, 'NA', 'NA'] == df.iloc[1].tolist()
-
 
         input_samples = pd.DataFrame([
             ['A', f1, pd.NA, pd.NA],

--- a/genomics_data_index/test/unit/variant/pipelines/test_SnakemakePipelineExecutor.py
+++ b/genomics_data_index/test/unit/variant/pipelines/test_SnakemakePipelineExecutor.py
@@ -155,6 +155,82 @@ def test_skip_samples_from_input_files():
     assert 0 == len(df)
 
 
+def test_skip_missing_sample_files():
+    with tempfile.NamedTemporaryFile() as f1_tmp:
+        f1 = Path(f1_tmp.name)
+
+        executor = SnakemakePipelineExecutor()
+
+        input_samples = pd.DataFrame([
+            ['A', f1, pd.NA, pd.NA],
+            ['B', f1, pd.NA, pd.NA],
+            ['C', pd.NA, f1, f1]
+        ], columns=['Sample', 'Assemblies', 'Reads1', 'Reads2'])
+
+        df = executor.skip_missing_sample_files(input_samples)
+        df = df.fillna('NA')
+        assert ['Sample', 'Assemblies', 'Reads1', 'Reads2'] == df.columns.tolist()
+        assert 3 == len(df)
+        assert ['A', f1, 'NA', 'NA'] == df.iloc[0].tolist()
+        assert ['B', f1, 'NA', 'NA'] == df.iloc[1].tolist()
+        assert ['C', 'NA', f1, f1] == df.iloc[2].tolist()
+
+
+        input_samples = pd.DataFrame([
+            ['A', f1, pd.NA, pd.NA],
+            ['B', Path('file2.fasta'), pd.NA, pd.NA],
+            ['C', pd.NA, Path('file_1.fastq'), Path('file_2.fastq')]
+        ], columns=['Sample', 'Assemblies', 'Reads1', 'Reads2'])
+
+        df = executor.skip_missing_sample_files(input_samples)
+        df = df.fillna('NA')
+        assert ['Sample', 'Assemblies', 'Reads1', 'Reads2'] == df.columns.tolist()
+        assert 1 == len(df)
+        assert ['A', f1, 'NA', 'NA'] == df.iloc[0].tolist()
+
+
+        input_samples = pd.DataFrame([
+            ['A', f1, pd.NA, pd.NA],
+            ['B', f1, pd.NA, pd.NA],
+            ['C', pd.NA, Path('file_1.fastq'), Path('file_2.fastq')]
+        ], columns=['Sample', 'Assemblies', 'Reads1', 'Reads2'])
+
+        df = executor.skip_missing_sample_files(input_samples)
+        df = df.fillna('NA')
+        assert ['Sample', 'Assemblies', 'Reads1', 'Reads2'] == df.columns.tolist()
+        assert 2 == len(df)
+        assert ['A', f1, 'NA', 'NA'] == df.iloc[0].tolist()
+        assert ['B', f1, 'NA', 'NA'] == df.iloc[1].tolist()
+
+
+        input_samples = pd.DataFrame([
+            ['A', f1, pd.NA, pd.NA],
+            ['B', f1, pd.NA, pd.NA],
+            ['C', pd.NA, f1, Path('file_2.fastq')]
+        ], columns=['Sample', 'Assemblies', 'Reads1', 'Reads2'])
+
+        df = executor.skip_missing_sample_files(input_samples)
+        df = df.fillna('NA')
+        assert ['Sample', 'Assemblies', 'Reads1', 'Reads2'] == df.columns.tolist()
+        assert 2 == len(df)
+        assert ['A', f1, 'NA', 'NA'] == df.iloc[0].tolist()
+        assert ['B', f1, 'NA', 'NA'] == df.iloc[1].tolist()
+
+
+        input_samples = pd.DataFrame([
+            ['A', f1, pd.NA, pd.NA],
+            ['B', Path('file2.fasta'), pd.NA, pd.NA],
+            ['C', pd.NA, f1, f1]
+        ], columns=['Sample', 'Assemblies', 'Reads1', 'Reads2'])
+
+        df = executor.skip_missing_sample_files(input_samples)
+        df = df.fillna('NA')
+        assert ['Sample', 'Assemblies', 'Reads1', 'Reads2'] == df.columns.tolist()
+        assert 2 == len(df)
+        assert ['A', f1, 'NA', 'NA'] == df.iloc[0].tolist()
+        assert ['C', 'NA', f1, f1] == df.iloc[1].tolist()
+
+
 def test_validate_input_sample_files():
     input_samples = pd.DataFrame([
         ['A', Path('file.fasta'), pd.NA, pd.NA],

--- a/genomics_data_index/test/unit/variant/pipelines/test_SnakemakePipelineExecutor.py
+++ b/genomics_data_index/test/unit/variant/pipelines/test_SnakemakePipelineExecutor.py
@@ -104,6 +104,57 @@ def test_create_input_sample_files_reads_and_assemblies_duplicate_sample_names_2
     assert 'Duplicate sample with name [SampleA]' in str(execinfo.value)
 
 
+def test_skip_samples_from_input_files():
+    input_samples = pd.DataFrame([
+        ['A', Path('file.fasta'), pd.NA, pd.NA],
+        ['B', Path('file2.fasta'), pd.NA, pd.NA],
+        ['C', pd.NA, Path('file_1.fastq'), Path('file_2.fastq')]
+    ], columns=['Sample', 'Assemblies', 'Reads1', 'Reads2'])
+
+    executor = SnakemakePipelineExecutor()
+
+    df = executor.skip_samples_from_input_files(input_samples, skip_samples=None)
+    df = df.fillna('NA')
+    assert ['Sample', 'Assemblies', 'Reads1', 'Reads2'] == df.columns.tolist()
+    assert 3 == len(df)
+    assert ['A', Path('file.fasta'), 'NA', 'NA'] == df.iloc[0].tolist()
+    assert ['B', Path('file2.fasta'), 'NA', 'NA'] == df.iloc[1].tolist()
+    assert ['C', 'NA', Path('file_1.fastq'), Path('file_2.fastq')] == df.iloc[2].tolist()
+
+    df = executor.skip_samples_from_input_files(input_samples, skip_samples=set())
+    df = df.fillna('NA')
+    assert ['Sample', 'Assemblies', 'Reads1', 'Reads2'] == df.columns.tolist()
+    assert 3 == len(df)
+    assert ['A', Path('file.fasta'), 'NA', 'NA'] == df.iloc[0].tolist()
+    assert ['B', Path('file2.fasta'), 'NA', 'NA'] == df.iloc[1].tolist()
+    assert ['C', 'NA', Path('file_1.fastq'), Path('file_2.fastq')] == df.iloc[2].tolist()
+
+    df = executor.skip_samples_from_input_files(input_samples, skip_samples={'A'})
+    df = df.fillna('NA')
+    assert ['Sample', 'Assemblies', 'Reads1', 'Reads2'] == df.columns.tolist()
+    assert 2 == len(df)
+    assert ['B', Path('file2.fasta'), 'NA', 'NA'] == df.iloc[0].tolist()
+    assert ['C', 'NA', Path('file_1.fastq'), Path('file_2.fastq')] == df.iloc[1].tolist()
+
+    df = executor.skip_samples_from_input_files(input_samples, skip_samples=set('B'))
+    df = df.fillna('NA')
+    assert ['Sample', 'Assemblies', 'Reads1', 'Reads2'] == df.columns.tolist()
+    assert 2 == len(df)
+    assert ['A', Path('file.fasta'), 'NA', 'NA'] == df.iloc[0].tolist()
+    assert ['C', 'NA', Path('file_1.fastq'), Path('file_2.fastq')] == df.iloc[1].tolist()
+
+    df = executor.skip_samples_from_input_files(input_samples, skip_samples={'A', 'C', 'invalid'})
+    df = df.fillna('NA')
+    assert ['Sample', 'Assemblies', 'Reads1', 'Reads2'] == df.columns.tolist()
+    assert 1 == len(df)
+    assert ['B', Path('file2.fasta'), 'NA', 'NA'] == df.iloc[0].tolist()
+
+    df = executor.skip_samples_from_input_files(input_samples, skip_samples={'A', 'B', 'C'})
+    df = df.fillna('NA')
+    assert ['Sample', 'Assemblies', 'Reads1', 'Reads2'] == df.columns.tolist()
+    assert 0 == len(df)
+
+
 def test_validate_input_sample_files():
     input_samples = pd.DataFrame([
         ['A', Path('file.fasta'), pd.NA, pd.NA],

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(name='genomics-data-index',
-      version='0.5.0.dev0',
+      version='0.5.0.dev1',
       description='Indexes genomics data (mutations, kmers, MLST) for fast querying of features.',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
Adds support for skipping samples that already exist in an index. That is, if you try to run an analysis or generate an input file from a list of samples, I will skip samples that already exist.

Also adds additional checks to make sure files referenced by samples exist before performing the analysis.