### PR TITLE
Fixed issue with missing indels in SARS-CoV-2

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -34,7 +34,7 @@ jobs:
           conda config --add channels defaults
           conda config --add channels conda-forge
           conda config --add channels bioconda
-          conda install mamba setuptools=57 htslib bcftools>=1.13 samtools>=1.13 bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
+          conda install mamba setuptools=57 htslib bcftools>=1.13 samtools>=1.13 openssl=1.0 bamtool minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
 
       - name: Setup python packages
         shell: bash -l {0}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -34,7 +34,7 @@ jobs:
           conda config --add channels defaults
           conda config --add channels conda-forge
           conda config --add channels bioconda
-          conda install mamba setuptools=57 htslib bcftools>=1.13 samtools>=1.13 openssl=1.0 bamtool minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
+          conda install mamba setuptools=57 htslib bcftools>=1.13 samtools>=1.13 openssl=1.0 bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
 
       - name: Setup python packages
         shell: bash -l {0}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -32,8 +32,8 @@ jobs:
           conda info
           conda list
           conda config --add channels defaults
-          conda config --add channels conda-forge
           conda config --add channels bioconda
+          conda config --add channels conda-forge
           conda install mamba setuptools=57 htslib bcftools>=1.13 samtools>=1.13 bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
 
       - name: Setup python packages

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -26,6 +26,12 @@ jobs:
           activate-environment: test
           python-version: ${{ matrix.python-version }}
 
+      - name: Install additional dependencies
+        shell: bash -l {0}
+        run: |
+          sudo apt update
+          sudo apt install libssl1.0.0
+
       - name: Install conda packages
         shell: bash -l {0}
         run: |
@@ -35,7 +41,6 @@ jobs:
           conda config --add channels conda-forge
           conda config --add channels bioconda
           conda install mamba setuptools=57 htslib bcftools>=1.13 samtools>=1.13 bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
-          sudo apt install libssl1.0.0
 
       - name: Setup python packages
         shell: bash -l {0}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -34,7 +34,7 @@ jobs:
           conda config --add channels defaults
           conda config --add channels conda-forge
           conda config --add channels bioconda
-          conda install mamba setuptools=57 htslib bcftools>=1.13 samtools>=1.13 openssl=1.0 bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
+          conda install mamba setuptools=57 htslib bcftools>=1.13 samtools>=1.13 bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
 
       - name: Setup python packages
         shell: bash -l {0}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash -l {0}
         run: |
           sudo apt update
-          sudo apt install libssl1.0.0
+          sudo apt install libssl1.0-dev
 
       - name: Install conda packages
         shell: bash -l {0}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -32,9 +32,10 @@ jobs:
           conda info
           conda list
           conda config --add channels defaults
-          conda config --add channels bioconda
           conda config --add channels conda-forge
+          conda config --add channels bioconda
           conda install mamba setuptools=57 htslib bcftools>=1.13 samtools>=1.13 bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
+          sudo apt install libssl1.0.0
 
       - name: Setup python packages
         shell: bash -l {0}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -34,7 +34,7 @@ jobs:
           conda config --add channels defaults
           conda config --add channels conda-forge
           conda config --add channels bioconda
-          conda install mamba setuptools=57 htslib bcftools==1.12 samtools==1.12 bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
+          conda install mamba setuptools=57 htslib bcftools>=1.13 samtools>=1.13 bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
 
       - name: Setup python packages
         shell: bash -l {0}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -26,12 +26,6 @@ jobs:
           activate-environment: test
           python-version: ${{ matrix.python-version }}
 
-      - name: Install additional dependencies
-        shell: bash -l {0}
-        run: |
-          sudo apt update
-          sudo apt install libssl1.0-dev
-
       - name: Install conda packages
         shell: bash -l {0}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [cli]: Support for skipping non-existent paths in input file (0.5.0.dev1).
 * [cli]: Support for skipping samples already in an index during the data analysis (0.5.0.dev1).
-* [analysis]: Increased `--indel-bias` in `bcftools mpileup` for assembly analysis from default **1.00**. This was done since I found I was missing a small number of indels in SARS-CoV-2 analyses (they were being identified as missing/unknown instead). Also decreased quality score filtering from `10` for the same reason.
+* [analysis]: Increased `--indel-bias` in `bcftools mpileup` for assembly analysis from default **1.00**. This was done since I found I was missing a small number of indels in SARS-CoV-2 analyses (they were being identified as missing/unknown instead). Also decreased quality score filtering from `10` for the same reason (0.5.0.dev2).
     * This requires bcftools >= 1.13.
 
 # 0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [cli]: Support for skipping non-existent paths in input file (0.5.0.dev1).
 * [cli]: Support for skipping samples already in an index during the data analysis (0.5.0.dev1).
+* [analysis]: Changed `--indel-bias` in `bcftools mpileup` for assembly analysis from default **1.00** to **1.1**. This was done since I found I was missing a small number of indels in SARS-CoV-2 analyses (they were being identified as missing/unknown instead).
 
 # 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [cli]: Support for skipping non-existent paths in input file (0.5.0.dev1).
 * [cli]: Support for skipping samples already in an index during the data analysis (0.5.0.dev1).
-* [analysis]: Changed `--indel-bias` in `bcftools mpileup` for assembly analysis from default **1.00** to **1.1**. This was done since I found I was missing a small number of indels in SARS-CoV-2 analyses (they were being identified as missing/unknown instead).
+* [analysis]: Increased `--indel-bias` in `bcftools mpileup` for assembly analysis from default **1.00**. This was done since I found I was missing a small number of indels in SARS-CoV-2 analyses (they were being identified as missing/unknown instead). Also decreased quality score filtering from `10` for the same reason.
 
 # 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [cli]: Support for skipping non-existent paths in input file (0.5.0.dev1).
 * [cli]: Support for skipping samples already in an index during the data analysis (0.5.0.dev1).
 * [analysis]: Increased `--indel-bias` in `bcftools mpileup` for assembly analysis from default **1.00**. This was done since I found I was missing a small number of indels in SARS-CoV-2 analyses (they were being identified as missing/unknown instead). Also decreased quality score filtering from `10` for the same reason.
+    * This requires bcftools >= 1.13.
 
 # 0.4.0
 

--- a/conda-env.yaml
+++ b/conda-env.yaml
@@ -9,7 +9,7 @@ dependencies:
   - bedtools
   - fasttree
   - iqtree
-  - bcftools
+  - bcftools >= 1.13
   - htslib
   - jupyterlab
   - matplotlib

--- a/genomics_data_index/__init__.py
+++ b/genomics_data_index/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = '0.5.0.dev1'
+__version__: str = '0.5.0.dev2'

--- a/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
+++ b/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
@@ -127,7 +127,7 @@ rule assembly_variant_all:
         filter="logs/assembly_variant_all.{sample}.view.log",
         tags="logs/assembly_variant_all.{sample}.tags.log",
     shell:
-        "bcftools mpileup -a DP --min-ireads 1 --indel-bias {indel_bias} --threads {threads} -Ou -f {input.reference} {input.bam} 2> {log.mpileup} | "
+        "bcftools mpileup -a DP --min-ireads 1 --indel-bias {params.indel_bias} --threads {threads} -Ou -f {input.reference} {input.bam} 2> {log.mpileup} | "
         "bcftools call --threads {threads} --ploidy 1 -Ou --multiallelic-caller 2> {log.call} | "
         "bcftools norm -f {input.reference} --threads {threads} --old-rec-tag -Ou 2> {log.norm} | "
         "bcftools view --include 'QUAL>{params.qual}' -Ou 2> {log.filter} | "

--- a/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
+++ b/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
@@ -115,11 +115,11 @@ rule assembly_variant_all:
         "envs/bcftools.yaml"
     threads: 1
     params:
-        qual=10,
+        qual=8,
 	
 	# Changed --indel-bias in bcftools mpileup from default of 1.00 since 
 	# otherwise I was missing a small number of indels in SARS-CoV-2
-	indel_bias=1.1,
+	indel_bias=5,
     log:
         mpileup="logs/assembly_variant_all.{sample}.mpileup.log",
         call="logs/assembly_variant_all.{sample}.call.log",

--- a/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
+++ b/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
@@ -88,7 +88,7 @@ rule prepare_snpeff_database:
         "scripts/prepare-snpeff-database.py"
 
 
-rule assembly_align:
+rule assembly_align: 
     input:
         reference_mm2_index="reference/reference.fasta.mmi",
         sample=lambda wildcards: sample_files.loc[wildcards.sample]['Assemblies'],
@@ -116,6 +116,10 @@ rule assembly_variant_all:
     threads: 1
     params:
         qual=10,
+	
+	# Changed --indel-bias in bcftools mpileup from default of 1.00 since 
+	# otherwise I was missing a small number of indels in SARS-CoV-2
+	indel_bias=1.1,
     log:
         mpileup="logs/assembly_variant_all.{sample}.mpileup.log",
         call="logs/assembly_variant_all.{sample}.call.log",
@@ -123,7 +127,7 @@ rule assembly_variant_all:
         filter="logs/assembly_variant_all.{sample}.view.log",
         tags="logs/assembly_variant_all.{sample}.tags.log",
     shell:
-        "bcftools mpileup -a DP --min-ireads 1 --threads {threads} -Ou -f {input.reference} {input.bam} 2> {log.mpileup} | "
+        "bcftools mpileup -a DP --min-ireads 1 --indel-bias {indel_bias} --threads {threads} -Ou -f {input.reference} {input.bam} 2> {log.mpileup} | "
         "bcftools call --threads {threads} --ploidy 1 -Ou --multiallelic-caller 2> {log.call} | "
         "bcftools norm -f {input.reference} --threads {threads} --old-rec-tag -Ou 2> {log.norm} | "
         "bcftools view --include 'QUAL>{params.qual}' -Ou 2> {log.filter} | "

--- a/genomics_data_index/pipelines/snakemake/main/workflow/envs/bcftools.yaml
+++ b/genomics_data_index/pipelines/snakemake/main/workflow/envs/bcftools.yaml
@@ -3,5 +3,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bcftools
+  - bcftools >= 1.13
   - gzip

--- a/genomics_data_index/pipelines/snakemake/main/workflow/envs/main.yaml
+++ b/genomics_data_index/pipelines/snakemake/main/workflow/envs/main.yaml
@@ -6,6 +6,6 @@ dependencies:
   - python=3
   - biopython
   - samtools
-  - bcftools
+  - bcftools >= 1.13
   - htslib
   - cat

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(name='genomics-data-index',
-      version='0.5.0.dev1',
+      version='0.5.0.dev2',
       description='Indexes genomics data (mutations, kmers, MLST) for fast querying of features.',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
* Fixes an issue with missing indels in SARS-CoV-2. This was due to the default value of `1.00` for `--indel-bias` in `bcftools-mpileup`. I updated to `5`.