### PR TITLE
Fix/quality thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [cli]: Support for skipping samples already in an index during the data analysis (0.5.0.dev1).
 * [analysis]: Increased `--indel-bias` in `bcftools mpileup` for assembly analysis from default **1.00**. This was done since I found I was missing a small number of indels in SARS-CoV-2 analyses (they were being identified as missing/unknown instead). Also decreased quality score filtering from `10` for the same reason (0.5.0.dev2).
     * This requires bcftools >= 1.13.
+* [analysis]: Decreased quality score to a minimum of `1` and added a depth of coverage check (minimum of `1`) to the assemblies pipeline to not exclude some regions.
 
 # 0.4.0
 

--- a/genomics_data_index/__init__.py
+++ b/genomics_data_index/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = '0.5.0.dev2'
+__version__: str = '0.5.0.dev3'

--- a/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
+++ b/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
@@ -116,6 +116,7 @@ rule assembly_variant_all:
     threads: 1
     params:
         qual=8,
+	depth_cov=1,
 	
 	# Changed --indel-bias in bcftools mpileup from default of 1.00 since 
 	# otherwise I was missing a small number of indels in SARS-CoV-2
@@ -130,7 +131,7 @@ rule assembly_variant_all:
         "bcftools mpileup -a DP --min-ireads 1 --indel-bias {params.indel_bias} --threads {threads} -Ou -f {input.reference} {input.bam} 2> {log.mpileup} | "
         "bcftools call --threads {threads} --ploidy 1 -Ou --multiallelic-caller 2> {log.call} | "
         "bcftools norm -f {input.reference} --threads {threads} --old-rec-tag -Ou 2> {log.norm} | "
-        "bcftools view --include 'QUAL>{params.qual}' -Ou 2> {log.filter} | "
+        "bcftools view --include 'QUAL>={params.qual} & DP>={params.depth_cov}' -Ou 2> {log.filter} | "
         "bcftools plugin fill-tags -Oz -o {output.vcf} -- -t TYPE 2> {log.tags}"
 
 

--- a/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
+++ b/genomics_data_index/pipelines/snakemake/main/workflow/Snakefile
@@ -115,7 +115,7 @@ rule assembly_variant_all:
         "envs/bcftools.yaml"
     threads: 1
     params:
-        qual=8,
+        qual=1,
 	depth_cov=1,
 	
 	# Changed --indel-bias in bcftools mpileup from default of 1.00 since 
@@ -131,7 +131,7 @@ rule assembly_variant_all:
         "bcftools mpileup -a DP --min-ireads 1 --indel-bias {params.indel_bias} --threads {threads} -Ou -f {input.reference} {input.bam} 2> {log.mpileup} | "
         "bcftools call --threads {threads} --ploidy 1 -Ou --multiallelic-caller 2> {log.call} | "
         "bcftools norm -f {input.reference} --threads {threads} --old-rec-tag -Ou 2> {log.norm} | "
-        "bcftools view --include 'QUAL>={params.qual} & DP>={params.depth_cov}' -Ou 2> {log.filter} | "
+        "bcftools view --include '(QUAL>={params.qual}) & (INFO/DP>={params.depth_cov})' -Ou 2> {log.filter} | "
         "bcftools plugin fill-tags -Oz -o {output.vcf} -- -t TYPE 2> {log.tags}"
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(name='genomics-data-index',
-      version='0.5.0.dev2',
+      version='0.5.0.dev3',
       description='Indexes genomics data (mutations, kmers, MLST) for fast querying of features.',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
Attempt to lower quality thresholds to avoid inadvertently removing real data for assembly analysis.

Thresholds at this level let me detect `S:K417N` consistent with what Nextclade detects (both present and missing data, except for some frameshifts). However removing filtering entirely leads to large inconsistent results with "missing" data between my software and Nextclade.