### PR TITLE
Updated version of htslib

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -35,6 +35,7 @@ jobs:
           conda config --add channels conda-forge
           conda config --add channels bioconda
           conda install mamba setuptools=57 htslib>=1.13 bcftools>=1.13 samtools>=1.13 bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
+          conda list
 
       - name: Setup python packages
         shell: bash -l {0}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -34,7 +34,7 @@ jobs:
           conda config --add channels defaults
           conda config --add channels conda-forge
           conda config --add channels bioconda
-          conda install mamba setuptools=57 htslib>=1.13 bcftools>=1.13 samtools>=1.13 bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
+          conda install mamba setuptools=57 'htslib>=1.13' 'bcftools>=1.13' 'samtools>=1.13' bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
           conda list
 
       - name: Setup python packages

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -34,7 +34,7 @@ jobs:
           conda config --add channels defaults
           conda config --add channels conda-forge
           conda config --add channels bioconda
-          conda install mamba setuptools=57 htslib bcftools>=1.13 samtools>=1.13 bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
+          conda install mamba setuptools=57 htslib>=1.13 bcftools>=1.13 samtools>=1.13 bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
 
       - name: Setup python packages
         shell: bash -l {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [cli]: Support for skipping samples already in an index during the data analysis (0.5.0.dev1).
 * [analysis]: Increased `--indel-bias` in `bcftools mpileup` for assembly analysis from default **1.00**. This was done since I found I was missing a small number of indels in SARS-CoV-2 analyses (they were being identified as missing/unknown instead). Also decreased quality score filtering from `10` for the same reason (0.5.0.dev2).
     * This requires bcftools >= 1.13.
+* [install]: Fixed broken dependencies on installation (0.5.0.dev3).
 
 # 0.4.0
 

--- a/genomics_data_index/__init__.py
+++ b/genomics_data_index/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = '0.5.0.dev2'
+__version__: str = '0.5.0.dev3'

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(name='genomics-data-index',
-      version='0.5.0.dev2',
+      version='0.5.0.dev3',
       description='Indexes genomics data (mutations, kmers, MLST) for fast querying of features.',
       long_description=long_description,
       long_description_content_type="text/markdown",
@@ -59,6 +59,12 @@ setup(name='genomics-data-index',
           'Jinja2',
           'pathvalidate',
           'pytest',
+
+          # I do not know exactly why these two statements are required and aren't 
+          # picked up by the dependency resolver, but they seem to be necessary now.
+          # 'tomli' required by 'black' and the wrong version is being installed. This fixes it.
+          'tomli<2.0.0,>=0.2.6',
+          'zipp',
       ],
       python_requires="<3.9",
       packages=find_packages(),


### PR DESCRIPTION
Fixes issue with encountering the following errors:

1. `samtools: error while loading shared libraries: libcrypto.so.1.0.0: cannot open shared object file: No such file or directory`
2. `error: tomli 2.0.0 is installed but tomli<2.0.0,>=0.2.6 is required by {'black'}`

The first error is because I wasn't quoting the dependency versions in conda (e.g., `samtools>=1.13`). The second error I'm not sure of, but I added some additional dependencies to `setup.py` and it appears to install properly now.