### PR TITLE
Update defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [api]: Updates to pruning of tree when joining external tree to query (0.5.0.dev5).
 * [api]: Add **Unknown** and **Present and Unknown** categories to `query.features_comparison()` output (0.5.0.dev6).
 * [api]: Added **use_only_samples_in_categories** parameter to `query.features_comparison()` (0.5.0.dev7).
+* [api]: Added ability to pass a list of features to a query: `query.hasa(features_list)`. This is an alternative to `query.hasa(f1).hasa(f2)...` (0.5.0.dev8).
 
 # 0.4.0
 

--- a/genomics_data_index/__init__.py
+++ b/genomics_data_index/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = '0.5.0.dev7'
+__version__: str = '0.5.0.dev8'

--- a/genomics_data_index/api/query/GenomicsDataIndex.py
+++ b/genomics_data_index/api/query/GenomicsDataIndex.py
@@ -115,7 +115,7 @@ class GenomicsDataIndex:
 
     def mutations_summary(self, reference_name: str, id_type: str = 'spdi_ref', include_present_features: bool = True,
                           include_unknown_features: bool = False,
-                          include_unknown_samples: bool = True,
+                          include_unknown_samples: bool = False,
                           include_unknown_no_present_samples: bool = False,
                           ignore_annotations: bool = False) -> pd.DataFrame:
         """
@@ -143,7 +143,7 @@ class GenomicsDataIndex:
 
     def mlst_summary(self, scheme_name: str, locus: str = None, include_present_features: bool = True,
                      include_unknown_features: bool = False,
-                     include_unknown_samples: bool = True,
+                     include_unknown_samples: bool = False,
                      include_unknown_no_present_samples: bool = False) -> pd.DataFrame:
         """
         Summarizes all MLST alleles stored in this index relative to the passed scheme name.
@@ -168,7 +168,7 @@ class GenomicsDataIndex:
 
     def features_summary(self, kind: str = 'mutations', scope: str = None,
                          include_present_features: bool = True, include_unknown_features: bool = False,
-                         include_unknown_samples: bool = True, include_unknown_no_present_samples: bool = False,
+                         include_unknown_samples: bool = False, include_unknown_no_present_samples: bool = False,
                          **kwargs) -> pd.DataFrame:
         """
         Summarizes all features stored in this index relative to a string for the passed scope.
@@ -202,7 +202,7 @@ class GenomicsDataIndex:
 
     def _mlst_summary_internal(self, scheme_name: str, locus: str = None, include_present_features: bool = True,
                                include_unknown_features: bool = False,
-                               include_unknown_samples: bool = True,
+                               include_unknown_samples: bool = False,
                                include_unknown_no_present_samples: bool = False
                                ) -> pd.DataFrame:
         """
@@ -231,7 +231,7 @@ class GenomicsDataIndex:
     def _mutations_summary_internal(self, reference_name: str, id_type: str = 'spdi_ref',
                                     include_present_features: bool = True,
                                     include_unknown_features: bool = False,
-                                    include_unknown_samples: bool = True,
+                                    include_unknown_samples: bool = False,
                                     include_unknown_no_present_samples: bool = False,
                                     ignore_annotations: bool = False) -> pd.DataFrame:
         """

--- a/genomics_data_index/api/query/SamplesQuery.py
+++ b/genomics_data_index/api/query/SamplesQuery.py
@@ -366,21 +366,24 @@ class SamplesQuery(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def hasa(self, property: Union[QueryFeature, str, pd.Series], kind='mutation') -> SamplesQuery:
+    def hasa(self, property: Union[QueryFeature, str, pd.Series, List[QueryFeature], List[str]],
+             kind='mutation') -> SamplesQuery:
         """
         Queries for samples that have a (**hasa**) particular feature/property. That is if `A` is a SamplesQuery
         and `m` is a mutation, then A.hasa(m) selects all those samples of A that have the mutation m.
 
         :param property: The particular property/feature to query by. This can be either QueryFeature defining
         the particular feature, a string defining the feature, or a pandas Series consisting of boolean values
-        which is the result of a DataFrame selection expression.
+        which is the result of a DataFrame selection expression. A list of QueryFeature or strings can also be
+        passed, which will be interpreted as hasa(feature1) AND hasa(feature2) AND ...
         :param kind: The kind of *property* that was passed.
 
         :return: A new SamplesQuery consisting of those samples that have the passed property.
         """
         pass
 
-    def has(self, property: Union[QueryFeature, str, pd.Series], kind='mutation') -> SamplesQuery:
+    def has(self, property: Union[QueryFeature, str, pd.Series, List[QueryFeature], List[str]],
+             kind='mutation') -> SamplesQuery:
         """
         Queries for samples that have a particular property. Synonym for hasa().
         """

--- a/genomics_data_index/api/query/SamplesQuery.py
+++ b/genomics_data_index/api/query/SamplesQuery.py
@@ -152,7 +152,7 @@ class SamplesQuery(abc.ABC):
     @abc.abstractmethod
     def features_summary(self, kind: str = 'mutations', selection: str = 'all',
                          include_present_features: bool = True, include_unknown_features: bool = False,
-                         include_unknown_samples: bool = True, include_unknown_no_present_samples: bool = False,
+                         include_unknown_samples: bool = False, include_unknown_no_present_samples: bool = False,
                          **kwargs) -> pd.DataFrame:
         """
         Summarizes the selected features in a DataFrame. Please specify the kind of features with the kind parameter.
@@ -195,7 +195,7 @@ class SamplesQuery(abc.ABC):
                             kind: str = 'mutations',
                             unit: str = 'percent',
                             category_samples_threshold: int = None,
-                            include_unknown_samples: bool = True, include_unknown_no_present_samples: bool = False,
+                            include_unknown_samples: bool = False, include_unknown_no_present_samples: bool = False,
                             use_only_samples_in_categories: bool = True,
                             **kwargs) -> pd.DataFrame:
         """

--- a/genomics_data_index/api/query/impl/DataFrameSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/DataFrameSamplesQuery.py
@@ -87,7 +87,7 @@ class DataFrameSamplesQuery(WrappedSamplesQuery):
                             kind: str = 'mutations',
                             unit: str = 'percent',
                             category_samples_threshold: int = None,
-                            include_unknown_samples: bool = True, include_unknown_no_present_samples: bool = False,
+                            include_unknown_samples: bool = False, include_unknown_no_present_samples: bool = False,
                             use_only_samples_in_categories: bool = True,
                             **kwargs) -> pd.DataFrame:
         if categories_kind == 'dataframe':

--- a/genomics_data_index/api/query/impl/SamplesQueryIndex.py
+++ b/genomics_data_index/api/query/impl/SamplesQueryIndex.py
@@ -256,7 +256,7 @@ class SamplesQueryIndex(SamplesQuery):
 
     def features_summary(self, kind: str = 'mutations', selection: str = 'all',
                          include_present_features: bool = True, include_unknown_features: bool = False,
-                         include_unknown_samples: bool = True, include_unknown_no_present_samples: bool = False,
+                         include_unknown_samples: bool = False, include_unknown_no_present_samples: bool = False,
                          **kwargs) -> pd.DataFrame:
         if kind == 'mutations':
             features_summarizier = MutationFeaturesFromIndexComparator(connection=self._query_connection,
@@ -289,7 +289,7 @@ class SamplesQueryIndex(SamplesQuery):
                             kind: str = 'mutations',
                             unit: str = 'percent',
                             category_samples_threshold: int = None,
-                            include_unknown_samples: bool = True, include_unknown_no_present_samples: bool = False,
+                            include_unknown_samples: bool = False, include_unknown_no_present_samples: bool = False,
                             use_only_samples_in_categories: bool = True,
                             **kwargs) -> pd.DataFrame:
         if kind == 'mutations':

--- a/genomics_data_index/api/query/impl/SamplesQueryIndex.py
+++ b/genomics_data_index/api/query/impl/SamplesQueryIndex.py
@@ -470,8 +470,14 @@ class SamplesQueryIndex(SamplesQuery):
         else:
             return SampleSet.create_empty()
 
-    def hasa(self, property: Union[QueryFeature, str, pd.Series], kind='mutation') -> SamplesQuery:
-        if isinstance(property, QueryFeature):
+    def hasa(self, property: Union[QueryFeature, str, pd.Series, List[QueryFeature], List[str]],
+             kind='mutation') -> SamplesQuery:
+        if isinstance(property, list):
+            list_query = self
+            for list_property in property:
+                list_query = list_query.hasa(list_property, kind=kind)
+            return list_query
+        elif isinstance(property, QueryFeature):
             query_feature = property
         elif isinstance(property, pd.Series):
             raise Exception(f'The query type {self.__class__.__name__} cannot support querying with respect to a '

--- a/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
@@ -91,10 +91,13 @@ class WrappedSamplesQuery(SamplesQuery, abc.ABC):
 
     def features_summary(self, kind: str = 'mutations', selection: str = 'all',
                          include_present_features: bool = False, include_unknown_features: bool = False,
+                         include_unknown_samples: bool = False, include_unknown_no_present_samples: bool = False,
                          **kwargs) -> pd.DataFrame:
         return self._wrapped_query.features_summary(kind=kind, selection=selection,
                                                     include_present_features=include_present_features,
                                                     include_unknown_features=include_unknown_features,
+                                                    include_unknown_samples=include_unknown_samples,
+                                                    include_unknown_no_present_samples=include_unknown_no_present_samples,
                                                     **kwargs)
 
     def features_comparison(self, sample_categories: Union[List[SamplesQuery], List[SampleSet], str],

--- a/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
@@ -90,7 +90,7 @@ class WrappedSamplesQuery(SamplesQuery, abc.ABC):
         return self._wrapped_query.summary()
 
     def features_summary(self, kind: str = 'mutations', selection: str = 'all',
-                         include_present_features: bool = True, include_unknown_features: bool = False,
+                         include_present_features: bool = False, include_unknown_features: bool = False,
                          **kwargs) -> pd.DataFrame:
         return self._wrapped_query.features_summary(kind=kind, selection=selection,
                                                     include_present_features=include_present_features,
@@ -103,7 +103,7 @@ class WrappedSamplesQuery(SamplesQuery, abc.ABC):
                             kind: str = 'mutations',
                             unit: str = 'percent',
                             category_samples_threshold: int = None,
-                            include_unknown_samples: bool = True, include_unknown_no_present_samples: bool = False,
+                            include_unknown_samples: bool = False, include_unknown_no_present_samples: bool = False,
                             use_only_samples_in_categories: bool = True,
                             **kwargs) -> pd.DataFrame:
         return self._wrapped_query.features_comparison(sample_categories=sample_categories,

--- a/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
@@ -133,7 +133,8 @@ class WrappedSamplesQuery(SamplesQuery, abc.ABC):
         return self._wrap_create(self._wrapped_query.subsample(k=k, include_unknown=include_unknown,
                                                                seed=seed))
 
-    def hasa(self, property: Union[QueryFeature, str, pd.Series], kind='mutation') -> SamplesQuery:
+    def hasa(self, property: Union[QueryFeature, str, pd.Series, List[QueryFeature], List[str]],
+             kind='mutation') -> SamplesQuery:
         return self._wrap_create(self._wrapped_query.hasa(property=property, kind=kind))
 
     def _get_has_kinds(self) -> List[str]:

--- a/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
+++ b/genomics_data_index/api/query/impl/WrappedSamplesQuery.py
@@ -90,7 +90,7 @@ class WrappedSamplesQuery(SamplesQuery, abc.ABC):
         return self._wrapped_query.summary()
 
     def features_summary(self, kind: str = 'mutations', selection: str = 'all',
-                         include_present_features: bool = False, include_unknown_features: bool = False,
+                         include_present_features: bool = True, include_unknown_features: bool = False,
                          include_unknown_samples: bool = False, include_unknown_no_present_samples: bool = False,
                          **kwargs) -> pd.DataFrame:
         return self._wrapped_query.features_summary(kind=kind, selection=selection,

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex.py
@@ -303,7 +303,7 @@ def test_summaries_mlst_data(loaded_database_genomic_data_store: GenomicsDataInd
             'Total', 'Percent', 'Unknown Percent', 'Present and Unknown Percent'] == list(summary_df.columns)
 
     # Summaries using 'mlst_summery()'
-    summary_df = gds.mlst_summary(scheme_name='lmonocytogenes')
+    summary_df = gds.mlst_summary(scheme_name='lmonocytogenes', include_unknown_samples=True)
     assert 10 == len(summary_df)
 
 
@@ -323,7 +323,7 @@ def test_summaries_variant_annotations(
     assert 177 == gds.count_mutations('NC_011083')
 
     # spdi
-    ms = gds.mutations_summary('NC_011083', id_type='spdi', ignore_annotations=False)
+    ms = gds.mutations_summary('NC_011083', id_type='spdi', ignore_annotations=False, include_unknown_samples=True)
     assert 177 == len(ms)
     assert 'Mutation' == ms.index.name
     assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
@@ -402,7 +402,7 @@ def test_summaries_variant_annotations(
         ms.loc['NC_011083:1676762:2:C'].fillna('<NA>'))
 
     # spdi_ref
-    ms = gds.mutations_summary('NC_011083', id_type='spdi_ref')
+    ms = gds.mutations_summary('NC_011083', id_type='spdi_ref', include_unknown_samples=True)
     assert 177 == len(ms)
     assert 'Mutation' == ms.index.name
     assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex.py
@@ -212,7 +212,7 @@ def test_summaries_mlst_data(loaded_database_genomic_data_store: GenomicsDataInd
     gds = loaded_database_genomic_data_store
 
     # MLST summaries for lmonocytogenes
-    summary_df = gds.features_summary(kind='mlst', scope='lmonocytogenes')
+    summary_df = gds.features_summary(kind='mlst', scope='lmonocytogenes', include_unknown_samples=True)
     summary_df['Percent'] = summary_df['Percent'].astype(int)  # Convert to int for easier comparison
     summary_df['Unknown Count'] = summary_df['Unknown Count'].fillna(-1).astype(int)
     summary_df['Present and Unknown Count'] = summary_df['Present and Unknown Count'].fillna(-1).astype(int)
@@ -234,7 +234,8 @@ def test_summaries_mlst_data(loaded_database_genomic_data_store: GenomicsDataInd
         'mlst:lmonocytogenes:ldh:5'].tolist()
 
     # MLST summaries for lmonocytogenes include unknown
-    summary_df = gds.features_summary(kind='mlst', scope='lmonocytogenes', include_unknown_features=True)
+    summary_df = gds.features_summary(kind='mlst', scope='lmonocytogenes', include_unknown_features=True,
+                                      include_unknown_samples=True)
     summary_df['Percent'] = summary_df['Percent'].astype(int)  # Convert to int for easier comparison
     summary_df['Unknown Count'] = summary_df['Unknown Count'].fillna(-1).astype(int)
     summary_df['Present and Unknown Count'] = summary_df['Present and Unknown Count'].fillna(-1).astype(int)
@@ -258,7 +259,7 @@ def test_summaries_mlst_data(loaded_database_genomic_data_store: GenomicsDataInd
         'mlst:lmonocytogenes:ldh:?'].tolist()
 
     # MLST summaries for lmonocytogenes with specific locus id
-    summary_df = gds.features_summary(kind='mlst', scope='lmonocytogenes', locus='bglA')
+    summary_df = gds.features_summary(kind='mlst', scope='lmonocytogenes', locus='bglA', include_unknown_samples=True)
     summary_df['Percent'] = summary_df['Percent'].astype(int)  # Convert to int for easier comparison
     summary_df['Unknown Count'] = summary_df['Unknown Count'].fillna(-1).astype(int)
     summary_df['Present and Unknown Count'] = summary_df['Present and Unknown Count'].fillna(-1).astype(int)
@@ -275,7 +276,7 @@ def test_summaries_mlst_data(loaded_database_genomic_data_store: GenomicsDataInd
 
     # MLST summaries for lmonocytogenes include unknown and not present
     summary_df = gds.features_summary(kind='mlst', scope='lmonocytogenes', include_present_features=False,
-                                      include_unknown_features=True)
+                                      include_unknown_features=True, include_unknown_samples=True)
     summary_df['Percent'] = summary_df['Percent'].astype(int)  # Convert to int for easier comparison
     summary_df['Unknown Count'] = summary_df['Unknown Count'].fillna(-1).astype(int)
     summary_df['Present and Unknown Count'] = summary_df['Present and Unknown Count'].fillna(-1).astype(int)
@@ -290,7 +291,7 @@ def test_summaries_mlst_data(loaded_database_genomic_data_store: GenomicsDataInd
 
     # MLST summaries for lmonocytogenes not include present or unknown
     summary_df = gds.features_summary(kind='mlst', scope='lmonocytogenes', include_present_features=False,
-                                      include_unknown_features=False)
+                                      include_unknown_features=False, include_unknown_samples=True)
     summary_df['Percent'] = summary_df['Percent'].astype(int)  # Convert to int for easier comparison
     summary_df['Unknown Count'] = summary_df['Unknown Count'].fillna(-1).astype(int)
     summary_df['Present and Unknown Count'] = summary_df['Present and Unknown Count'].fillna(-1).astype(int)

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
@@ -1466,8 +1466,8 @@ def test_query_chained_mutation_has_mutation(loaded_database_connection: DataInd
     assert 9 == len(query_result.universe_set)
 
     query_result = query(loaded_database_connection).hasa(
-        ['reference:839:C:G'
-        'reference:5061:G:A'], kind='mutation')
+        ['reference:839:C:G',
+         'reference:5061:G:A'], kind='mutation')
     assert 1 == len(query_result)
     assert {sampleB.id} == set(query_result.sample_set)
     assert 9 == len(query_result.universe_set)

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
@@ -3563,7 +3563,7 @@ def test_summary_features_kindmutations_annotations(
     q = query(loaded_database_connection_annotations_unknown)
 
     # 1 sample
-    mutations_df = q.isa('SH10-014').features_summary(ignore_annotations=False)
+    mutations_df = q.isa('SH10-014').features_summary(ignore_annotations=False, include_unknown_samples=True)
 
     assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Count', 'Unknown Count', 'Present and Unknown Count', 'Total',
@@ -3607,7 +3607,8 @@ def test_summary_features_kindmutations_annotations(
         mutations_df.loc['NC_011083:4555461:T:TC'].fillna('NA'))
 
     # 3 samples
-    mutations_df = q.isin(['SH10-014', 'SH14-001', 'SH14-014']).features_summary(ignore_annotations=False)
+    mutations_df = q.isin(['SH10-014', 'SH14-001', 'SH14-014']).features_summary(ignore_annotations=False,
+                                                                                 include_unknown_samples=True)
 
     ## Convert percent to int to make it easier to compare in assert statements
     mutations_df['Percent'] = mutations_df['Percent'].astype(int)
@@ -3643,7 +3644,8 @@ def test_summary_features_kindmutations_annotations(
         mutations_df.loc['NC_011083:4555461:T:TC'].fillna('NA'))
 
     # Test ignore annotations
-    mutations_df = q.isin(['SH10-014', 'SH14-001', 'SH14-014']).features_summary(ignore_annotations=True)
+    mutations_df = q.isin(['SH10-014', 'SH14-001', 'SH14-014']).features_summary(ignore_annotations=True,
+                                                                                 include_unknown_samples=True)
 
     assert ['Sequence', 'Position', 'Deletion', 'Insertion', 'Type',
             'Count', 'Unknown Count', 'Present and Unknown Count', 'Total',
@@ -3651,7 +3653,8 @@ def test_summary_features_kindmutations_annotations(
     assert 177 == len(mutations_df)
 
     # Test unique, not including unknown with no present samples
-    mutations_df = q.isa('SH10-014').features_summary(selection='unique', ignore_annotations=False)
+    mutations_df = q.isa('SH10-014').features_summary(selection='unique', ignore_annotations=False,
+                                                      include_unknown_samples=True)
 
     ## Convert percent to int to make it easier to compare in assert statements
     mutations_df['Percent'] = mutations_df['Percent'].astype(int)
@@ -3688,7 +3691,8 @@ def test_summary_features_kindmutations_annotations(
 
     # Test unique, including unknown with no present samples
     mutations_df = q.isa('SH10-014').features_summary(selection='unique', ignore_annotations=False,
-                                                      include_unknown_no_present_samples=True)
+                                                      include_unknown_no_present_samples=True,
+                                                      include_unknown_samples=True)
 
     ## Convert percent to int to make it easier to compare in assert statements
     mutations_df['Percent'] = mutations_df['Percent'].astype(int)
@@ -3759,7 +3763,8 @@ def test_summary_features_two(loaded_database_connection: DataIndexConnection):
 
 def test_summary_features_kindmlst(loaded_database_connection: DataIndexConnection):
     # Test case of summary of single sample
-    summary_df = query(loaded_database_connection).isa('SampleA').features_summary(kind='mlst')
+    summary_df = query(loaded_database_connection).isa('SampleA').features_summary(kind='mlst',
+                                                                                   include_unknown_samples=True)
     summary_df['Percent'] = summary_df['Percent'].astype(int)  # Convert to int for easier comparison
     summary_df['Unknown Percent'] = summary_df['Unknown Percent'].astype(int)
     summary_df['Present and Unknown Percent'] = summary_df['Present and Unknown Percent'].astype(int)
@@ -3775,7 +3780,8 @@ def test_summary_features_kindmlst(loaded_database_connection: DataIndexConnecti
 
     # Test samples across multiple schemes
     summary_df = query(loaded_database_connection).isin(['SampleA', 'SampleB', 'CFSAN002349',
-                                                         '2014D-0067']).features_summary(kind='mlst')
+                                                         '2014D-0067']).features_summary(kind='mlst',
+                                                                                         include_unknown_samples=True)
     summary_df['Percent'] = summary_df['Percent'].astype(int)  # Convert to int for easier comparison
     assert 15 == len(summary_df)
     assert {'lmonocytogenes', 'campylobacter'} == set(summary_df['Scheme'].tolist())
@@ -3801,7 +3807,8 @@ def test_summary_features_kindmlst(loaded_database_connection: DataIndexConnecti
     # Test samples across multiple schemes including unknown with no present samples
     summary_df = query(loaded_database_connection).isin(['SampleA', 'SampleB', 'CFSAN002349',
                                                          '2014D-0067']).features_summary(kind='mlst',
-                                                                                         include_unknown_no_present_samples=True)
+                                                                                         include_unknown_no_present_samples=True,
+                                                                                         include_unknown_samples=True)
     summary_df['Percent'] = summary_df['Percent'].astype(int)  # Convert to int for easier comparison
     assert 16 == len(summary_df)
     assert {'lmonocytogenes', 'campylobacter'} == set(summary_df['Scheme'].tolist())
@@ -3828,7 +3835,7 @@ def test_summary_features_kindmlst(loaded_database_connection: DataIndexConnecti
     # Test only unknown
     summary_df = query(loaded_database_connection).isin(
         ['SampleA', 'SampleB', 'CFSAN002349', '2014D-0067']).features_summary(
-        kind='mlst', include_present_features=False, include_unknown_features=True)
+        kind='mlst', include_present_features=False, include_unknown_features=True, include_unknown_samples=True)
     summary_df['Percent'] = summary_df['Percent'].astype(int)  # Convert to int for easier comparison
     summary_df['Unknown Count'] = summary_df['Unknown Count'].fillna(-1)
     summary_df['Unknown Count'] = summary_df['Unknown Count'].astype(int)
@@ -3852,7 +3859,8 @@ def test_summary_features_kindmlst(loaded_database_connection: DataIndexConnecti
     # Test only unknown, restrict scheme
     summary_df = query(loaded_database_connection).isin(
         ['SampleA', 'SampleB', 'CFSAN002349', '2014D-0067']).features_summary(
-        kind='mlst', scheme='lmonocytogenes', include_present_features=False, include_unknown_features=True)
+        kind='mlst', scheme='lmonocytogenes', include_present_features=False, include_unknown_features=True,
+        include_unknown_samples=True)
     summary_df['Percent'] = summary_df['Percent'].astype(int)  # Convert to int for easier comparison
     summary_df['Unknown Count'] = summary_df['Unknown Count'].fillna(-1)
     summary_df['Unknown Count'] = summary_df['Unknown Count'].astype(int)
@@ -3882,6 +3890,7 @@ def test_features_comparison_kindmutations_annotations(
     # Test 2 categories counts
     comparison_df = q.features_comparison(sample_categories=[category_10, category_14],
                                           category_prefixes=['10', '14'],
+                                          include_unknown_samples=True,
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     comparison_df = comparison_df.fillna('<NA>')
@@ -3960,7 +3969,7 @@ def test_features_comparison_kindmutations_annotations(
     assert 'SNP' == comparison_df.loc['NC_011083:140658:C:A', 'Type']
 
     # Test 2 categories defaults
-    comparison_df = q.features_comparison(sample_categories=[category_10, category_14])
+    comparison_df = q.features_comparison(sample_categories=[category_10, category_14], include_unknown_samples=True)
     comparison_df = comparison_df.sort_index()
     comparison_df = comparison_df.fillna('<NA>')
     comparison_df['Category1_percent'] = comparison_df['Category1_percent'].astype(
@@ -4028,6 +4037,7 @@ def test_features_comparison_kindmutations_annotations(
     comparison_df = q.isin(['SH14-001', 'SH14-014']).features_comparison(
         sample_categories=[category_10, category_14],
         category_prefixes=['10', '14'],
+        include_unknown_samples=True,
         unit='percent'
     )
     comparison_df = comparison_df.sort_index()
@@ -4112,6 +4122,7 @@ def test_features_comparison_kindmlst(loaded_database_connection: DataIndexConne
     comparison_df = q.features_comparison(sample_categories=[category_lmonocytogenes, category_other],
                                           category_prefixes=['lmonocytogenes', 'other'],
                                           unit='percent',
+                                          include_unknown_samples=True,
                                           kind='mlst')
     assert 24 == len(comparison_df)
     assert 'MLST Feature' == comparison_df.index.name
@@ -4180,6 +4191,7 @@ def test_features_comparison_kindmlst(loaded_database_connection: DataIndexConne
                                                              category_other.sample_set],
                                           category_prefixes=['lmonocytogenes', 'other'],
                                           unit='percent',
+                                          include_unknown_samples=True,
                                           kind='mlst')
     assert 24 == len(comparison_df)
     assert 'MLST Feature' == comparison_df.index.name
@@ -4248,6 +4260,7 @@ def test_features_comparison_kindmlst(loaded_database_connection: DataIndexConne
     comparison_df = q_subset.features_comparison(sample_categories=[category_lmonocytogenes, category_other],
                                                  category_prefixes=['lmonocytogenes', 'other'],
                                                  unit='percent',
+                                                 include_unknown_samples=True,
                                                  kind='mlst')
     assert 16 == len(comparison_df)
     assert 'MLST Feature' == comparison_df.index.name
@@ -4328,6 +4341,7 @@ def test_features_comparison_kindmutations_with_dataframe(
     # Test 2 categories counts on dataframe query: dataframe column groupby
     comparison_df = q.features_comparison(sample_categories='Color',
                                           categories_kind='dataframe',
+                                          include_unknown_samples=True,
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     comparison_df = comparison_df.fillna('<NA>')
@@ -4405,6 +4419,7 @@ def test_features_comparison_kindmutations_with_dataframe(
     # Test 2 categories counts on dataframe query: sample_query
     comparison_df = q.features_comparison(sample_categories=[category_10, category_14],
                                           category_prefixes=['10', '14'],
+                                          include_unknown_samples=True,
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     comparison_df = comparison_df.fillna('<NA>')
@@ -4483,6 +4498,7 @@ def test_features_comparison_kindmutations_with_dataframe(
     comparison_df = q.features_comparison(sample_categories='Color',
                                           categories_kind='dataframe',
                                           category_samples_threshold=1,
+                                          include_unknown_samples=True,
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     comparison_df = comparison_df.fillna('<NA>')
@@ -4561,6 +4577,7 @@ def test_features_comparison_kindmutations_with_dataframe(
     comparison_df = q.features_comparison(sample_categories='Color',
                                           categories_kind='dataframe',
                                           category_samples_threshold=2,
+                                          include_unknown_samples=True,
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     comparison_df = comparison_df.fillna('<NA>')
@@ -4613,6 +4630,7 @@ def test_features_comparison_kindmutations_with_dataframe(
                                           categories_kind='dataframe',
                                           category_samples_threshold=2,
                                           use_only_samples_in_categories=False,
+                                          include_unknown_samples=True,
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     comparison_df = comparison_df.fillna('<NA>')
@@ -4664,6 +4682,7 @@ def test_features_comparison_kindmutations_with_dataframe(
     comparison_df = q.features_comparison(sample_categories=[category_10, category_14],
                                           category_prefixes=['10', '14'],
                                           category_samples_threshold=2,
+                                          include_unknown_samples=True,
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     comparison_df = comparison_df.fillna('<NA>')
@@ -4716,6 +4735,7 @@ def test_features_comparison_kindmutations_with_dataframe(
                                           category_prefixes=['10', '14'],
                                           category_samples_threshold=2,
                                           use_only_samples_in_categories=False,
+                                          include_unknown_samples=True,
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     comparison_df = comparison_df.fillna('<NA>')
@@ -4773,6 +4793,7 @@ def test_features_comparison_kindmutations_with_dataframe(
               data_frame=df, sample_ids_column='Sample ID')
     comparison_df = q.features_comparison(sample_categories='Color',
                                           categories_kind='dataframe',
+                                          include_unknown_samples=True,
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     comparison_df = comparison_df.fillna('<NA>')
@@ -4835,6 +4856,7 @@ def test_features_comparison_kindmutations_with_dataframe(
               data_frame=df, sample_ids_column='Sample ID')
     comparison_df = q.features_comparison(sample_categories='Color',
                                           categories_kind='dataframe',
+                                          include_unknown_samples=True,
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     comparison_df = comparison_df.fillna('<NA>')
@@ -4881,6 +4903,7 @@ def test_features_comparison_kindmutations_with_dataframe(
     comparison_df = q.features_comparison(sample_categories='Color',
                                           categories_kind='dataframe',
                                           use_only_samples_in_categories=False,
+                                          include_unknown_samples=True,
                                           unit='count')
     comparison_df = comparison_df.sort_index()
     comparison_df = comparison_df.fillna('<NA>')

--- a/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
+++ b/genomics_data_index/test/integration/api/query/test_GenomicsDataIndex_samples_query.py
@@ -1446,6 +1446,13 @@ def test_query_chained_mutation(loaded_database_connection: DataIndexConnection)
     assert {sampleB.id} == set(query_result.sample_set)
     assert 9 == len(query_result.universe_set)
 
+    query_result = query(loaded_database_connection).hasa(
+        [QueryFeatureMutationSPDI('reference:839:C:G'),
+         QueryFeatureMutationSPDI('reference:5061:G:A')])
+    assert 1 == len(query_result)
+    assert {sampleB.id} == set(query_result.sample_set)
+    assert 9 == len(query_result.universe_set)
+
 
 def test_query_chained_mutation_has_mutation(loaded_database_connection: DataIndexConnection):
     db = loaded_database_connection.database
@@ -1454,6 +1461,13 @@ def test_query_chained_mutation_has_mutation(loaded_database_connection: DataInd
     query_result = query(loaded_database_connection).hasa(
         'reference:839:C:G', kind='mutation').hasa(
         'reference:5061:G:A', kind='mutation')
+    assert 1 == len(query_result)
+    assert {sampleB.id} == set(query_result.sample_set)
+    assert 9 == len(query_result.universe_set)
+
+    query_result = query(loaded_database_connection).hasa(
+        ['reference:839:C:G'
+        'reference:5061:G:A'], kind='mutation')
     assert 1 == len(query_result)
     assert {sampleB.id} == set(query_result.sample_set)
     assert 9 == len(query_result.universe_set)
@@ -1558,6 +1572,28 @@ def test_query_chained_mlst_nucleotide(loaded_database_connection: DataIndexConn
     query_result = query(loaded_database_connection) \
         .hasa('mlst:lmonocytogenes:bglA:52', kind='mlst') \
         .hasa('reference:3319:1:G', kind='mutation')
+    assert 0 == len(query_result)
+    assert 1 == len(query_result.unknown_set)
+    assert {sampleB.id} == set(query_result.unknown_set)
+    assert 8 == len(query_result.absent_set)
+    assert all_sample_ids - {sampleB.id} == set(query_result.absent_set)
+    assert 9 == len(query_result.universe_set)
+
+    # Test query MLST then mutation that will be switched to unknown, QueryFeatures
+    query_result = query(loaded_database_connection).hasa(
+        QueryFeatureMLST('mlst:lmonocytogenes:bglA:52')).hasa(
+        QueryFeatureMutationSPDI('reference:3319:1:G'))
+    assert 0 == len(query_result)
+    assert 1 == len(query_result.unknown_set)
+    assert {sampleB.id} == set(query_result.unknown_set)
+    assert 8 == len(query_result.absent_set)
+    assert all_sample_ids - {sampleB.id} == set(query_result.absent_set)
+    assert 9 == len(query_result.universe_set)
+
+    # Test query MLST then mutation that will be switched to unknown, QueryFeatures list
+    query_result = query(loaded_database_connection).hasa(
+        [QueryFeatureMLST('mlst:lmonocytogenes:bglA:52'),
+         QueryFeatureMutationSPDI('reference:3319:1:G')])
     assert 0 == len(query_result)
     assert 1 == len(query_result.unknown_set)
     assert {sampleB.id} == set(query_result.unknown_set)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(name='genomics-data-index',
-      version='0.5.0.dev7',
+      version='0.5.0.dev8',
       description='Indexes genomics data (mutations, kmers, MLST) for fast querying of features.',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
* Switched `features_summary()` and `features_comparison` parameter `include_unknown_samples` to **False** by default due to this particular bit of code taking a very long time to run.
* Added ability to pass a list of features to a query: `query.hasa(features_list)`. This is an alternative to `query.hasa(f1).hasa(f2)...` (0.5.0.dev8).