### PR TITLE
Updating CI tests

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -36,7 +36,7 @@ jobs:
           conda config --add channels conda-forge
           conda config --set channel_priority strict
           conda install mamba -y
-          mamba install pip 'htslib==1.13' 'bcftools==1.13' 'samtools==1.13' bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
+          mamba install pip 'htslib>=1.13' 'bcftools>=1.13' 'samtools>=1.13' bamtools minimap2 bedtools fasttree iqtree perl==5.22.0.1 mlst pyqt snpeff -y
           conda list
 
       - name: Setup python packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     * GDI will not currently work in Python 3.10 due in particular to this issue (https://github.com/etetoolkit/ete/issues/635), which does not exist below 3.10.
 * [installation]: Removed restriction on version of snpeff.
 * [analysis]: Added option `--no-snpeff-reference-check` to disable reference genome CDS and Protein checking when building snpeff database. To support building snpeff genome databases with problematic genomes (see https://github.com/pcingola/SnpEff/issues/388).
+* [installation]: Removed requirement exact version of bcftools and htslib. Now only needs `bcftools>=1.13` and `htslib>=1.13`.
 
 # 0.7.0
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Additionally, a poster on this project can be found at [immem2022][].
 To install this software, we will first, create a conda environment with the necessary dependencies as follows (a full conda package is not available yet https://github.com/apetkau/genomics-data-index/issues/51 ).
 
 ```bash
-conda create -c conda-forge -c bioconda -c defaults --name gdi python=3.8 pyqt bedtools iqtree 'bcftools==1.13' 'htslib==1.13'
+conda create -c conda-forge -c bioconda -c defaults --name gdi python=3.8 pyqt bedtools iqtree 'bcftools>=1.13' 'htslib>=1.13'
 
 # Activate environment. Needed to install additional Python dependencies below.
 conda activate gdi


### PR DESCRIPTION
[installation]: Removed requirement exact version of bcftools and htslib. Now only needs `bcftools>=1.13` and `htslib>=1.13`.