### PR TITLE
Updated conda environments to use gdi 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.1
+
+* [analysis]: Updated conda environments for analysis to use gdi `0.8.0` (required me to release this version first).
+
 # 0.8.0
 
 * [ci]: Fixed GitHub integration tests.

--- a/genomics_data_index/__init__.py
+++ b/genomics_data_index/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = '0.8.0'
+__version__: str = '0.8.1'

--- a/genomics_data_index/pipelines/snakemake/main/workflow/envs/gdi.yaml
+++ b/genomics_data_index/pipelines/snakemake/main/workflow/envs/gdi.yaml
@@ -3,12 +3,11 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python=3.8
+  - "python<3.10"
   - bedtools
-  - setuptools=57
   - numpy
   - pip
   - pip:
     # I install a separate copy of my software here so that I have access to classes I've written
     # In my project, but within a conda environment for the Snakemake pipeline.
-    - genomics-data-index==0.5.0
+    - genomics-data-index==0.8.0

--- a/genomics_data_index/pipelines/snakemake/main/workflow/envs/snpeff.yaml
+++ b/genomics_data_index/pipelines/snakemake/main/workflow/envs/snpeff.yaml
@@ -3,11 +3,10 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - snpeff==5.0
+  - snpeff
   - biopython
   - htslib
-  - python=3.8
-  - setuptools=57
+  - "python<3.10"
   - pip
   - pip:
-    - genomics-data-index==0.5.0
+    - genomics-data-index==0.8.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(name='genomics-data-index',
-      version='0.8.0',
+      version='0.8.1',
       description='Indexes genomics data (mutations, kmers, MLST) for fast querying of features.',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
* [analysis]: Updated conda environments for analysis to use gdi `0.8.0` (required me to release this version first).